### PR TITLE
Fix Tab child control call

### DIFF
--- a/comerzzia-pampling-pos-gui/src/main/java/com/comerzzia/pampling/pos/gui/ventas/tickets/pagos/PamplingPagosController.java
+++ b/comerzzia-pampling-pos-gui/src/main/java/com/comerzzia/pampling/pos/gui/ventas/tickets/pagos/PamplingPagosController.java
@@ -179,15 +179,15 @@ public class PamplingPagosController extends PagosController {
         * envuelven en un bloque try/catch para evitar fallos en tiempo de
         * ejecución si no están presentes.
         */
-       private void hideCashDenominationButtons() {
-               try {
-                       if (panelPestanaPagoEfectivo != null) {
-                               panelPestanaPagoEfectivo.getChildren().clear();
-                               panelPestanaPagoEfectivo.getChildren().add(btAnotarPago);
-                       }
-               }
-               catch (Exception e) {
-                       log.debug("No se pudieron ocultar los botones de denominaciones: " + e.getMessage());
-               }
-       }
+      private void hideCashDenominationButtons() {
+              try {
+                      if (panelPagoEfectivo != null) {
+                              panelPagoEfectivo.getChildren().clear();
+                              panelPagoEfectivo.getChildren().add(btAnotarPago);
+                      }
+              }
+              catch (Exception e) {
+                      log.debug("No se pudieron ocultar los botones de denominaciones: " + e.getMessage());
+              }
+      }
 }


### PR DESCRIPTION
## Summary
- adjust `hideCashDenominationButtons` to access the AnchorPane instead of the Tab

## Testing
- `mvn test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6846c761b7b8832b848c0e57a7e86f01