### PR TITLE
Enable CashlogyManager when active

### DIFF
--- a/comerzzia-pampling-pos-gui/src/main/java/com/comerzzia/pampling/pos/services/payments/PamplingPaymentsManagerImpl.java
+++ b/comerzzia-pampling-pos-gui/src/main/java/com/comerzzia/pampling/pos/services/payments/PamplingPaymentsManagerImpl.java
@@ -14,17 +14,25 @@ import com.comerzzia.pos.services.payments.methods.PaymentMethodManager;
 @Scope("prototype")
 public class PamplingPaymentsManagerImpl extends PaymentsManagerImpl {
 
-	public boolean isCashlogyEnable() {
-		//Por si no esta definido el medio de pago por defecto que me coja el EFECTIVO
-		String key = (MediosPagosService.medioPagoDefecto == null) ? "0000" : MediosPagosService.medioPagoDefecto.getCodMedioPago();
+       public boolean isCashlogyEnable() {
+               for (PaymentMethodManager manager : paymentsAvailable.values()) {
+                       if (manager instanceof CashlogyManager) {
+                               return ((CashlogyManager) manager).isCashlogyActivo();
+                       }
+               }
+               return false;
+       }
 
-		PaymentMethodManager paymentMethodManager = paymentsAvailable.get(key);
-
-		if (paymentMethodManager instanceof CashlogyManager) {
-			return ((CashlogyManager) paymentMethodManager).isCashlogyActivo();
-		}
-
-		return false;
-	}
+       /**
+        * Devuelve la instancia de {@link CashlogyManager} si está disponible.
+        */
+       public CashlogyManager getCashlogyManager() {
+               for (PaymentMethodManager manager : paymentsAvailable.values()) {
+                       if (manager instanceof CashlogyManager) {
+                               return (CashlogyManager) manager;
+                       }
+               }
+               return null;
+       }
 
 }


### PR DESCRIPTION
## Summary
- support CashlogyManager in `selectCustomPaymentMethod`
- hide cash denomination buttons when Cashlogy is enabled
- detect Cashlogy enablement regardless of default payment
- invoke CashlogyManager directly from `anotarPago`

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6846c444baa4832bb36a5779d1fc0527