### PR TITLE
Fix Cashlogy payments

### DIFF
--- a/comerzzia-pampling-pos-gui/src/main/java/com/comerzzia/pampling/pos/gui/ventas/tickets/pagos/PamplingPagosController.java
+++ b/comerzzia-pampling-pos-gui/src/main/java/com/comerzzia/pampling/pos/gui/ventas/tickets/pagos/PamplingPagosController.java
@@ -107,22 +107,32 @@ public class PamplingPagosController extends PagosController {
 		return FormatUtil.getInstance().desformateaImporte(tfImporte.getText());
 	}
 
-	@Override
-	public void anotarPago(BigDecimal importe) {
-		try {
-			IPrinter printer = Dispositivos.getInstance().getImpresora1();
-			if (printer instanceof GermanyFiscalPrinter && !((GermanyFiscalPrinter) printer).compruebaAutoTest()) {
-				VentanaDialogoComponent.crearVentanaError(I18N.getTexto("No se ha podido realizar la conexión con el TSE"), getStage());
-				return;
-			}
-		}
-		catch (Exception e) {
-			log.error("anotarPago() - " + e.getClass().getName() + " - " + e.getLocalizedMessage(), e);
-			VentanaDialogoComponent.crearVentanaError(I18N.getTexto("No se ha podido realizar la conexión con el TSE"), getStage());
-			return;
-		}
-		super.anotarPago(importe);
-	}
+       @Override
+       public void anotarPago(BigDecimal importe) {
+               try {
+                       IPrinter printer = Dispositivos.getInstance().getImpresora1();
+                       if (printer instanceof GermanyFiscalPrinter && !((GermanyFiscalPrinter) printer).compruebaAutoTest()) {
+                               VentanaDialogoComponent.crearVentanaError(I18N.getTexto("No se ha podido realizar la conexión con el TSE"), getStage());
+                               return;
+                       }
+
+                       PamplingPaymentsManagerImpl pm = (PamplingPaymentsManagerImpl) paymentsManager;
+                       if (pm.isCashlogyEnable()) {
+                               CashlogyManager manager = pm.getCashlogyManager();
+                               if (manager != null) {
+                                       manager.pay(importe);
+                                       return;
+                               }
+                       }
+               }
+               catch (Exception e) {
+                       log.error("anotarPago() - " + e.getClass().getName() + " - " + e.getLocalizedMessage(), e);
+                       VentanaDialogoComponent.crearVentanaError(I18N.getTexto("No se ha podido realizar la conexión con el TSE"), getStage());
+                       return;
+               }
+
+               super.anotarPago(importe);
+       }
 
 	@Override
 	public void aceptar() throws DocumentoException {
@@ -184,6 +194,11 @@ public class PamplingPagosController extends PagosController {
                       if (panelPagoEfectivo != null) {
                               panelPagoEfectivo.getChildren().clear();
                               panelPagoEfectivo.getChildren().add(btAnotarPago);
+                      }
+                      else if (panelPestanaPagoEfectivo instanceof javafx.scene.layout.Pane) {
+                              javafx.scene.layout.Pane pane = (javafx.scene.layout.Pane) panelPestanaPagoEfectivo;
+                              pane.getChildren().clear();
+                              pane.getChildren().add(btAnotarPago);
                       }
               }
               catch (Exception e) {

--- a/comerzzia-pampling-pos-gui/src/main/java/com/comerzzia/pampling/pos/services/payments/PamplingPaymentsManagerImpl.java
+++ b/comerzzia-pampling-pos-gui/src/main/java/com/comerzzia/pampling/pos/services/payments/PamplingPaymentsManagerImpl.java
@@ -14,7 +14,7 @@ import com.comerzzia.pos.services.payments.methods.PaymentMethodManager;
 @Scope("prototype")
 public class PamplingPaymentsManagerImpl extends PaymentsManagerImpl {
 
-	public boolean isCashlogyEnable() {
+        public boolean isCashlogyEnable() {
 		//Por si no esta definido el medio de pago por defecto que me coja el EFECTIVO
 		String key = (MediosPagosService.medioPagoDefecto == null) ? "0000" : MediosPagosService.medioPagoDefecto.getCodMedioPago();
 
@@ -24,7 +24,16 @@ public class PamplingPaymentsManagerImpl extends PaymentsManagerImpl {
 			return ((CashlogyManager) paymentMethodManager).isCashlogyActivo();
 		}
 
-		return false;
-	}
+                return false;
+        }
+
+       public CashlogyManager getCashlogyManager() {
+               String key = (MediosPagosService.medioPagoDefecto == null) ? "0000" : MediosPagosService.medioPagoDefecto.getCodMedioPago();
+               PaymentMethodManager paymentMethodManager = paymentsAvailable.get(key);
+               if (paymentMethodManager instanceof CashlogyManager) {
+                       return (CashlogyManager) paymentMethodManager;
+               }
+               return null;
+       }
 
 }


### PR DESCRIPTION
## Summary
- use CashlogyManager when cashlogy is active
- expose helper to retrieve the Cashlogy manager
- gracefully hide cash denomination buttons

## Testing
- `mvn --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ccdb4db8832baaeed2ce5febd769