### PR TITLE
Fix email validator domain length

### DIFF
--- a/pos-gui/src/main/java/com/comerzzia/bricodepot/pos/util/format/BricoEmailValidator.java
+++ b/pos-gui/src/main/java/com/comerzzia/bricodepot/pos/util/format/BricoEmailValidator.java
@@ -31,8 +31,9 @@ public class BricoEmailValidator extends EmailValidator {
 		String localPart = parts[0];
 		String domainPart = parts[1];
 
-		boolean advancedOk = localPart.length() <= 64 && domainPart.length() <= 255 && localPart.matches(LOCAL_PART_REGEX) && domainPart.matches(DOMAIN_REGEX)
-		        && Arrays.stream(domainPart.split("\\.")).allMatch(label -> label.matches(DOMAIN_LABEL_REGEX)) && INSTANCE.isValid(email, (ConstraintValidatorContext) null);
+                boolean advancedOk = localPart.length() <= 64 && domainPart.length() <= 255 && localPart.matches(LOCAL_PART_REGEX)
+                                && domainPart.matches(DOMAIN_REGEX)
+                                && Arrays.stream(domainPart.split("\\.")).allMatch(label -> label.matches(DOMAIN_LABEL_REGEX));
 
 		if (!advancedOk) {
 			return I18N.getTexto("El formato del email no es válido");


### PR DESCRIPTION
## Summary
- allow long domain addresses by removing super validator

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68492b73876c832bb8d7c631eb41d119