### PR TITLE
Fix loyalty search email validation

### DIFF
--- a/pos-gui/src/main/java/com/comerzzia/bricodepot/pos/dispositivo/fidelizacion/busqueda/BricoBusquedaFidelizadoController.java
+++ b/pos-gui/src/main/java/com/comerzzia/bricodepot/pos/dispositivo/fidelizacion/busqueda/BricoBusquedaFidelizadoController.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import com.comerzzia.bricodepot.pos.util.format.BricoEmailValidator;
 import com.comerzzia.pos.core.gui.componentes.dialogos.VentanaDialogoComponent;
+import org.apache.commons.lang3.StringUtils;
 import javafx.fxml.FXML;
 
 @Primary
@@ -17,11 +18,13 @@ public class BricoBusquedaFidelizadoController extends BusquedaFidelizadoControl
     @FXML
     public void accionAceptar() {
         String email = tfEmail.getText();
-        
-        String error = BricoEmailValidator.getValidationErrorKey(email);
-        if (error != null) {
-            VentanaDialogoComponent.crearVentanaConfirmacionUnBoton(error, getStage());
-            return;
+
+        if (StringUtils.isNotBlank(email)) {
+            String error = BricoEmailValidator.getValidationErrorKey(email);
+            if (error != null) {
+                VentanaDialogoComponent.crearVentanaConfirmacionUnBoton(error, getStage());
+                return;
+            }
         }
         
         super.accionAceptar();


### PR DESCRIPTION
## Summary
- avoid email validation when searching by document in loyalty search

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab05777ec832badf73c5ef651dcdd