### PR TITLE
Add cashlogy cash button

### DIFF
--- a/comerzzia-pampling-pos-gui/src/main/java/com/comerzzia/pampling/pos/gui/ventas/tickets/pagos/PamplingPagosController.java
+++ b/comerzzia-pampling-pos-gui/src/main/java/com/comerzzia/pampling/pos/gui/ventas/tickets/pagos/PamplingPagosController.java
@@ -28,13 +28,20 @@ import com.comerzzia.pos.services.ticket.pagos.PagoTicket;
 import com.comerzzia.pos.services.ticket.tarjetaRegalo.TarjetaRegaloException;
 import com.comerzzia.pos.util.format.FormatUtil;
 import com.comerzzia.pos.util.i18n.I18N;
+import javafx.fxml.FXML;
+import javafx.scene.control.Button;
 
 @Primary
 @Component
 public class PamplingPagosController extends PagosController {
 
-	@Autowired
-	protected GermanyFiscalPrinterService germanyFiscalPrinterService;
+        @Autowired
+        protected GermanyFiscalPrinterService germanyFiscalPrinterService;
+
+        @FXML
+        private Button btEfectivoCashlogy;
+
+        private boolean autoAceptarEfectivo = false;
 
 	@Override
 	protected void accionSalvarTicketOnFailure(Exception e) {
@@ -84,8 +91,17 @@ public class PamplingPagosController extends PagosController {
 		else {
 			addCustomPaymentData(eventOk, payment);
 		}
-		ticketManager.guardarCopiaSeguridadTicket();
-	}
+                ticketManager.guardarCopiaSeguridadTicket();
+
+                if (autoAceptarEfectivo && eventOk.getSource() instanceof ContadoManager) {
+                        autoAceptarEfectivo = false;
+                        try {
+                                aceptar();
+                        } catch (DocumentoException e) {
+                                VentanaDialogoComponent.crearVentanaError(getStage(), e.getMessage(), e);
+                        }
+                }
+        }
 
 	@Override
 	protected void selectCustomPaymentMethod(PaymentSelectEvent paymentSelectEvent) {
@@ -103,12 +119,12 @@ public class PamplingPagosController extends PagosController {
 	 * Método auxiliar que devuelve el importe actual ingresado en tfImporte.
 	 */
 
-	private BigDecimal eventualPaymentAmount() {
-		return FormatUtil.getInstance().desformateaImporte(tfImporte.getText());
-	}
+        private BigDecimal eventualPaymentAmount() {
+                return FormatUtil.getInstance().desformateaImporte(tfImporte.getText());
+        }
 
-	@Override
-	public void anotarPago(BigDecimal importe) {
+        @Override
+        public void anotarPago(BigDecimal importe) {
 		try {
 			IPrinter printer = Dispositivos.getInstance().getImpresora1();
 			if (printer instanceof GermanyFiscalPrinter && !((GermanyFiscalPrinter) printer).compruebaAutoTest()) {
@@ -121,8 +137,16 @@ public class PamplingPagosController extends PagosController {
 			VentanaDialogoComponent.crearVentanaError(I18N.getTexto("No se ha podido realizar la conexión con el TSE"), getStage());
 			return;
 		}
-		super.anotarPago(importe);
-	}
+                super.anotarPago(importe);
+        }
+
+        @FXML
+        private void accionBtEfectivoCashlogy() {
+                BigDecimal pendiente = ticketManager.getTicket().getTotales().getPendiente();
+                tfImporte.setText(FormatUtil.getInstance().formateaImporte(pendiente));
+                autoAceptarEfectivo = true;
+                anotarPago(pendiente);
+        }
 
 	@Override
 	public void aceptar() throws DocumentoException {
@@ -155,19 +179,29 @@ public class PamplingPagosController extends PagosController {
 	public void initializeForm() throws InitializeGuiException {
 		super.initializeForm();
 
-		boolean cashlogyActivo = ((PamplingPaymentsManagerImpl) paymentsManager).isCashlogyEnable();
-		log.debug("Inicializando formulario, cashlogyActivo=" + cashlogyActivo);
+                boolean cashlogyActivo = ((PamplingPaymentsManagerImpl) paymentsManager).isCashlogyEnable();
+                log.debug("Inicializando formulario, cashlogyActivo=" + cashlogyActivo);
 
-		if (cashlogyActivo) {
-			if (panelPagos.getTabs().contains(panelPestanaPagoEfectivo)) {
-				panelPagos.getTabs().remove(panelPestanaPagoEfectivo);
-			}
-		}
-		else {
-			if (!panelPagos.getTabs().contains(panelPestanaPagoEfectivo)) {
-				panelPagos.getTabs().add(0, panelPestanaPagoEfectivo);
-			}
-			panelPagos.getSelectionModel().select(panelPestanaPagoEfectivo);
-		}
-	}
+                if (cashlogyActivo) {
+                        if (botoneraImportes != null) {
+                                botoneraImportes.setVisible(false);
+                                botoneraImportes.setManaged(false);
+                        }
+                        btAnotarPago.setVisible(false);
+                        btAnotarPago.setManaged(false);
+                        btEfectivoCashlogy.setVisible(true);
+                        btEfectivoCashlogy.setManaged(true);
+                }
+                else {
+                        if (botoneraImportes != null) {
+                                botoneraImportes.setVisible(true);
+                                botoneraImportes.setManaged(true);
+                        }
+                        btAnotarPago.setVisible(true);
+                        btAnotarPago.setManaged(true);
+                        btEfectivoCashlogy.setVisible(false);
+                        btEfectivoCashlogy.setManaged(false);
+                }
+                panelPagos.getSelectionModel().select(panelPestanaPagoEfectivo);
+        }
 }

--- a/comerzzia-pampling-pos-gui/src/main/resources/skins/pampling/com/comerzzia/pos/gui/ventas/tickets/pagos/pagos.fxml
+++ b/comerzzia-pampling-pos-gui/src/main/resources/skins/pampling/com/comerzzia/pos/gui/ventas/tickets/pagos/pagos.fxml
@@ -117,16 +117,24 @@
                                 <AnchorPane fx:id="panelMediosPago" minHeight="169.0" prefHeight="191.0" 
                                             prefWidth="751.0">
                                   <children>
-                                    <TabPane fx:id="panelPagos" disable="false" focusTraversable="false" 
-                                             layoutX="0.0" layoutY="-1.0" minHeight="169.0" pickOnBounds="false" 
-                                             prefHeight="188.0" prefWidth="754.0" rotateGraphic="false" side="BOTTOM" 
+                                    <TabPane fx:id="panelPagos" disable="false" focusTraversable="false"
+                                             layoutX="0.0" layoutY="-1.0" minHeight="169.0" pickOnBounds="false"
+                                             prefHeight="188.0" prefWidth="754.0" rotateGraphic="false" side="BOTTOM"
                                              styleClass="tab-forma-pago" tabClosingPolicy="UNAVAILABLE" visible="true">
                                       <tabs>
                                         <Tab fx:id="panelPestanaPagoEfectivo" text="%Efectivo">
                                           <content>
-                                            <AnchorPane id="Content" fx:id="panelPagoEfectivo" focusTraversable="false" 
-                                                        minHeight="0.0" minWidth="0.0" prefHeight="133.0" 
-                                                        prefWidth="753.9999" />
+                                            <AnchorPane id="Content" fx:id="panelPagoEfectivo" focusTraversable="false"
+                                                        minHeight="0.0" minWidth="0.0" prefHeight="133.0"
+                                                        prefWidth="753.9999">
+                                              <children>
+                                                <Button fx:id="btEfectivoCashlogy" mnemonicParsing="false"
+                                                        onAction="#accionBtEfectivoCashlogy" text="%Efectivo"
+                                                        visible="false" managed="false"
+                                                        AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
+                                                        AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
+                                              </children>
+                                            </AnchorPane>
                                           </content>
                                         </Tab>
                                         <Tab fx:id="panelPestanaPagoTarjeta" text="%Tarjeta">


### PR DESCRIPTION
## Summary
- hide coin panel and show new `Efectivo` button inside the cash tab when Cashlogy is active
- clicking the new button pays with Cashlogy and automatically accepts the sale
- keep the tab and toggle the coin panel visibility based on Cashlogy state

## Testing
- `mvn -q -e -DskipTests install` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684adfb87274832bbb773c79c3ef4448