### PR TITLE
Add phone to ticket preview

### DIFF
--- a/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido.xml
+++ b/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido.xml
@@ -189,6 +189,13 @@
 		#if(${ticket.getTotales().getPuntos()} > 0)
 			 <linea><texto>Ha obtenido ${ticket.getTotales().getPuntos()} puntos en esta compra.</texto></linea>
 		#end
+        #if( $salida && $salida.equalsIgnoreCase("pantalla") && $ticket.getCabecera().getDatosFidelizado().getTelefono() )
+            <linea line-size="4">
+                <texto size="40" align="left">
+                    Teléfono ${ticket.getCabecera().getDatosFidelizado().getTelefono()}
+                </texto>
+            </linea>
+        #end
 	    <linea><texto></texto></linea>
 	#end
 

--- a/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_AD.xml
+++ b/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_AD.xml
@@ -180,6 +180,13 @@
 		#if(${ticket.getTotales().getPuntos()} > 0)
 			 <linea><texto>Ha obtenido ${ticket.getTotales().getPuntos()} puntos en esta compra.</texto></linea>
 		#end
+        #if( $salida && $salida.equalsIgnoreCase("pantalla") && $ticket.getCabecera().getDatosFidelizado().getTelefono() )
+            <linea line-size="4">
+                <texto size="40" align="left">
+                    Teléfono ${ticket.getCabecera().getDatosFidelizado().getTelefono()}
+                </texto>
+            </linea>
+        #end
 	    <linea><texto></texto></linea>
 	#end
 

--- a/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_CA.xml
+++ b/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_CA.xml
@@ -180,6 +180,13 @@
 		#if(${ticket.getTotales().getPuntos()} > 0)
 			 <linea><texto>Ha obtenido ${ticket.getTotales().getPuntos()} puntos en esta compra.</texto></linea>
 		#end
+        #if( $salida && $salida.equalsIgnoreCase("pantalla") && $ticket.getCabecera().getDatosFidelizado().getTelefono() )
+            <linea line-size="4">
+                <texto size="40" align="left">
+                    Teléfono ${ticket.getCabecera().getDatosFidelizado().getTelefono()}
+                </texto>
+            </linea>
+        #end
 	    <linea><texto></texto></linea>
 	#end
 

--- a/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_CL.xml
+++ b/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_CL.xml
@@ -209,6 +209,13 @@
 		<linea>
 			<texto>Ha obtenido ${ticket.getTotales().getPuntos()} puntos en esta compra.</texto>
 		</linea>
+        #if( $salida && $salida.equalsIgnoreCase("pantalla") && $ticket.getCabecera().getDatosFidelizado().getTelefono() )
+            <linea line-size="4">
+                <texto size="40" align="left">
+                    Teléfono ${ticket.getCabecera().getDatosFidelizado().getTelefono()}
+                </texto>
+            </linea>
+        #end
 				#end
 		<linea>
 			<texto/>

--- a/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_CO.xml
+++ b/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_CO.xml
@@ -210,6 +210,13 @@
 		#if(${ticket.getTotales().getPuntos()} > 0)
 			 <linea><texto>Ha obtenido ${ticket.getTotales().getPuntos()} puntos en esta compra.</texto></linea>		
 		#end
+        #if( $salida && $salida.equalsIgnoreCase("pantalla") && $ticket.getCabecera().getDatosFidelizado().getTelefono() )
+            <linea line-size="4">
+                <texto size="40" align="left">
+                    Teléfono ${ticket.getCabecera().getDatosFidelizado().getTelefono()}
+                </texto>
+            </linea>
+        #end
 	    <linea><texto></texto></linea>
 	#end 
 	<!-- CLIENTE -->

--- a/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_DE.xml
+++ b/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_DE.xml
@@ -174,6 +174,13 @@
 		#if(${ticket.getTotales().getPuntos()} > 0)
 			 <linea><texto>Ha obtenido ${ticket.getTotales().getPuntos()} puntos en esta compra.</texto></linea>
 		#end
+        #if( $salida && $salida.equalsIgnoreCase("pantalla") && $ticket.getCabecera().getDatosFidelizado().getTelefono() )
+            <linea line-size="4">
+                <texto size="40" align="left">
+                    Teléfono ${ticket.getCabecera().getDatosFidelizado().getTelefono()}
+                </texto>
+            </linea>
+        #end
 	   <!-- <linea><texto></texto></linea> -->
 	#end
 

--- a/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_EC.xml
+++ b/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_EC.xml
@@ -186,6 +186,13 @@
 		#if(${ticket.getTotales().getPuntos()} > 0)
 			 <linea><texto>Ha obtenido ${ticket.getTotales().getPuntos()} puntos en esta compra.</texto></linea>
 		#end
+        #if( $salida && $salida.equalsIgnoreCase("pantalla") && $ticket.getCabecera().getDatosFidelizado().getTelefono() )
+            <linea line-size="4">
+                <texto size="40" align="left">
+                    Teléfono ${ticket.getCabecera().getDatosFidelizado().getTelefono()}
+                </texto>
+            </linea>
+        #end
 	    <linea><texto></texto></linea>
 	#end
 	

--- a/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_EN.xml
+++ b/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_EN.xml
@@ -173,6 +173,13 @@
 		#if(${ticket.getTotales().getPuntos()} > 0)
 			 <linea><texto>Ha obtenido ${ticket.getTotales().getPuntos()} puntos en esta compra.</texto></linea>
 		#end
+        #if( $salida && $salida.equalsIgnoreCase("pantalla") && $ticket.getCabecera().getDatosFidelizado().getTelefono() )
+            <linea line-size="4">
+                <texto size="40" align="left">
+                    Teléfono ${ticket.getCabecera().getDatosFidelizado().getTelefono()}
+                </texto>
+            </linea>
+        #end
 	    <linea><texto></texto></linea>
 	#end
 

--- a/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_FR.xml
+++ b/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_FR.xml
@@ -180,6 +180,13 @@
 		#if(${ticket.getTotales().getPuntos()} > 0)
 			 <linea><texto>Ha obtenido ${ticket.getTotales().getPuntos()} puntos en esta compra.</texto></linea>
 		#end
+        #if( $salida && $salida.equalsIgnoreCase("pantalla") && $ticket.getCabecera().getDatosFidelizado().getTelefono() )
+            <linea line-size="4">
+                <texto size="40" align="left">
+                    Teléfono ${ticket.getCabecera().getDatosFidelizado().getTelefono()}
+                </texto>
+            </linea>
+        #end
 	    <!-- <linea><texto></texto></linea> -->
 	#end
 

--- a/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_MX.xml
+++ b/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_MX.xml
@@ -186,6 +186,13 @@
 		#if(${ticket.getTotales().getPuntos()} > 0)
 			 <linea><texto>Ha obtenido ${ticket.getTotales().getPuntos()} puntos en esta compra.</texto></linea>
 		#end
+        #if( $salida && $salida.equalsIgnoreCase("pantalla") && $ticket.getCabecera().getDatosFidelizado().getTelefono() )
+            <linea line-size="4">
+                <texto size="40" align="left">
+                    Teléfono ${ticket.getCabecera().getDatosFidelizado().getTelefono()}
+                </texto>
+            </linea>
+        #end
 	    <linea><texto></texto></linea>
 	#end
 

--- a/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_NL.xml
+++ b/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_NL.xml
@@ -173,6 +173,13 @@
 		#if(${ticket.getTotales().getPuntos()} > 0)
 			 <linea><texto>Ha obtenido ${ticket.getTotales().getPuntos()} puntos en esta compra.</texto></linea>
 		#end
+        #if( $salida && $salida.equalsIgnoreCase("pantalla") && $ticket.getCabecera().getDatosFidelizado().getTelefono() )
+            <linea line-size="4">
+                <texto size="40" align="left">
+                    Teléfono ${ticket.getCabecera().getDatosFidelizado().getTelefono()}
+                </texto>
+            </linea>
+        #end
 	    <!--<linea><texto></texto></linea> -->
 	#end
 

--- a/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_PA.xml
+++ b/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_PA.xml
@@ -191,6 +191,13 @@
 		#if(${ticket.getTotales().getPuntos()} > 0)
 			 <linea><texto>Ha obtenido ${ticket.getTotales().getPuntos()} puntos en esta compra.</texto></linea>
 		#end
+        #if( $salida && $salida.equalsIgnoreCase("pantalla") && $ticket.getCabecera().getDatosFidelizado().getTelefono() )
+            <linea line-size="4">
+                <texto size="40" align="left">
+                    Teléfono ${ticket.getCabecera().getDatosFidelizado().getTelefono()}
+                </texto>
+            </linea>
+        #end
 	    <linea><texto></texto></linea>
 	#end
 	

--- a/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_PL.xml
+++ b/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_PL.xml
@@ -168,6 +168,13 @@
 		#if(${ticket.getTotales().getPuntos()} > 0)
 			 <linea><texto>Ha obtenido ${ticket.getTotales().getPuntos()} puntos en esta compra.</texto></linea>
 		#end
+        #if( $salida && $salida.equalsIgnoreCase("pantalla") && $ticket.getCabecera().getDatosFidelizado().getTelefono() )
+            <linea line-size="4">
+                <texto size="40" align="left">
+                    Teléfono ${ticket.getCabecera().getDatosFidelizado().getTelefono()}
+                </texto>
+            </linea>
+        #end
 	    <linea><texto></texto></linea>
 	#end
 

--- a/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_PR.xml
+++ b/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_PR.xml
@@ -188,6 +188,13 @@
 		#if(${ticket.getTotales().getPuntos()} > 0)
 			 <linea><texto>Ha obtenido ${ticket.getTotales().getPuntos()} puntos en esta compra.</texto></linea>
 		#end
+        #if( $salida && $salida.equalsIgnoreCase("pantalla") && $ticket.getCabecera().getDatosFidelizado().getTelefono() )
+            <linea line-size="4">
+                <texto size="40" align="left">
+                    Teléfono ${ticket.getCabecera().getDatosFidelizado().getTelefono()}
+                </texto>
+            </linea>
+        #end
 	    <linea><texto></texto></linea>
 	#end
 

--- a/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_PT.xml
+++ b/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_PT.xml
@@ -198,6 +198,13 @@
 		#if(${ticket.getTotales().getPuntos()} > 0)
 			 <linea><texto>Ha obtenido ${ticket.getTotales().getPuntos()} puntos en esta compra.</texto></linea>
 		#end
+        #if( $salida && $salida.equalsIgnoreCase("pantalla") && $ticket.getCabecera().getDatosFidelizado().getTelefono() )
+            <linea line-size="4">
+                <texto size="40" align="left">
+                    Teléfono ${ticket.getCabecera().getDatosFidelizado().getTelefono()}
+                </texto>
+            </linea>
+        #end
 	    <!-- <linea><texto></texto></linea>  -->
 	#end
 	

--- a/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_SG.xml
+++ b/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_SG.xml
@@ -172,6 +172,13 @@
 		#if(${ticket.getTotales().getPuntos()} > 0)
 			 <linea><texto>Ha obtenido ${ticket.getTotales().getPuntos()} puntos en esta compra.</texto></linea>
 		#end
+        #if( $salida && $salida.equalsIgnoreCase("pantalla") && $ticket.getCabecera().getDatosFidelizado().getTelefono() )
+            <linea line-size="4">
+                <texto size="40" align="left">
+                    Teléfono ${ticket.getCabecera().getDatosFidelizado().getTelefono()}
+                </texto>
+            </linea>
+        #end
 	    <!--<linea><texto></texto></linea>  -->
 	#end
 

--- a/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_US.xml
+++ b/comerzzia-bimbaylola-pos-resources/configuracion/plantillas/factura_contenido_US.xml
@@ -174,6 +174,13 @@
 		#if(${ticket.getTotales().getPuntos()} > 0)
 			 <linea><texto>Ha obtenido ${ticket.getTotales().getPuntos()} puntos en esta compra.</texto></linea>
 		#end
+        #if( $salida && $salida.equalsIgnoreCase("pantalla") && $ticket.getCabecera().getDatosFidelizado().getTelefono() )
+            <linea line-size="4">
+                <texto size="40" align="left">
+                    Teléfono ${ticket.getCabecera().getDatosFidelizado().getTelefono()}
+                </texto>
+            </linea>
+        #end
 	    <linea><texto></texto></linea>
 	#end
 


### PR DESCRIPTION
## Summary
- show customer phone in pantalla previews for all factura templates

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fbf7a54c4832ba0d1edc24c720dd7