### PR TITLE
Enable Cashlogy sale cancellation

### DIFF
--- a/comerzzia-pampling-pos-gui/src/main/java/com/comerzzia/pampling/pos/core/gui/componentes/CashlogyVentanaCargando.java
+++ b/comerzzia-pampling-pos-gui/src/main/java/com/comerzzia/pampling/pos/core/gui/componentes/CashlogyVentanaCargando.java
@@ -40,8 +40,11 @@ public class CashlogyVentanaCargando extends Stage {
     protected Timer timer;
     protected int timeoutVentana = 0;
     
-    public static void crearVentanaCargando(Stage stageOwner) {
+    private static Runnable onCancel;
+
+    public static void crearVentanaCargando(Stage stageOwner, Runnable cancelAction) {
         ventana = new CashlogyVentanaCargando();
+        onCancel = cancelAction;
         ventana.timer = new Timer(10000, new ActionListener() {
             @Override
             public void actionPerformed(java.awt.event.ActionEvent e) {
@@ -82,6 +85,13 @@ public class CashlogyVentanaCargando extends Stage {
         btnCancelar.setStyle("-fx-font-size: 14px; -fx-padding: 6 20;");
         btnCancelar.setOnAction(event -> {
             log.info("Botón Cancelar pulsado");
+            if (onCancel != null) {
+                try {
+                    onCancel.run();
+                } catch (Exception e) {
+                    log.error("Error ejecutando acción de cancelación", e);
+                }
+            }
             cerrar();
         });
 

--- a/comerzzia-pampling-pos-gui/src/main/java/com/comerzzia/pampling/pos/gui/ventas/tickets/pagos/PamplingPagosController.java
+++ b/comerzzia-pampling-pos-gui/src/main/java/com/comerzzia/pampling/pos/gui/ventas/tickets/pagos/PamplingPagosController.java
@@ -13,6 +13,7 @@ import com.comerzzia.pampling.pos.devices.impresoras.fiscal.alemania.GermanyFisc
 import com.comerzzia.pampling.pos.services.fiscal.alemania.GermanyFiscalPrinterService;
 import com.comerzzia.pampling.pos.services.payments.PamplingPaymentsManagerImpl;
 import com.comerzzia.pampling.pos.services.payments.methods.types.CashlogyTask;
+import com.comerzzia.pampling.pos.services.payments.methods.types.CashlogyManager;
 import com.comerzzia.pos.core.dispositivos.Dispositivos;
 import com.comerzzia.pos.core.dispositivos.dispositivo.impresora.IPrinter;
 import com.comerzzia.pos.core.dispositivos.dispositivo.tarjeta.TarjetaException;
@@ -270,7 +271,11 @@ public class PamplingPagosController extends PagosController {
 					btAnotarPago.setDisable(false);
 
 				}
-			}.start(getStage());
+                        }.start(getStage(), () -> {
+                                if (paymentMethodManager instanceof CashlogyManager) {
+                                        ((CashlogyManager) paymentMethodManager).requestCancelSale();
+                                }
+                        });
 
 		}
 		else {

--- a/comerzzia-pampling-pos-gui/src/main/java/com/comerzzia/pampling/pos/services/payments/methods/types/CashlogyTask.java
+++ b/comerzzia-pampling-pos-gui/src/main/java/com/comerzzia/pampling/pos/services/payments/methods/types/CashlogyTask.java
@@ -8,29 +8,35 @@ import com.comerzzia.pos.core.gui.BackgroundTask;
 import javafx.stage.Stage;
 
 public abstract class CashlogyTask<V> extends BackgroundTask<V> {
-	
-	protected Stage stage;
+
+        protected Stage stage;
+        protected Runnable cancelAction;
 	
 	private static Logger log = Logger.getLogger(CashlogyTask.class);
 	
-	public void start(Stage stageR) {
-		
-		this.stage = stageR;
-		currentThread = new Thread(this);
-		currentThread.setName(this.getClass().toString());
-		currentThread.start();
-		
-		mostrarVentanaCargando();
+        public void start(Stage stageR) {
+                start(stageR, null);
+    }
+
+        public void start(Stage stageR, Runnable cancelAction) {
+
+                this.stage = stageR;
+                this.cancelAction = cancelAction;
+                currentThread = new Thread(this);
+                currentThread.setName(this.getClass().toString());
+                currentThread.start();
+
+                mostrarVentanaCargando();
 
     }
 	
 	@Override
-	protected void mostrarVentanaCargando(){
-    	if(mostrarVentanaCargando){
-    		CashlogyVentanaCargando.crearVentanaCargando(stage);
-    		CashlogyVentanaCargando.mostrar();
-            
-    	}
+        protected void mostrarVentanaCargando(){
+        if(mostrarVentanaCargando){
+                CashlogyVentanaCargando.crearVentanaCargando(stage, cancelAction);
+                CashlogyVentanaCargando.mostrar();
+
+        }
     }
 	
 	@Override


### PR DESCRIPTION
## Summary
- allow specifying cancel action when showing Cashlogy waiting window
- propagate cancel action through `CashlogyTask` and controller
- store sale context in `CashlogyManager` and send `CancelSale` on demand
- check for cancel request while polling and abort payment

## Testing
- `mvn -q -DskipTests=false test` *(fails: mvn not found)*
- `mvn -q -DskipTests=true package` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6851420247d8832b90908a49c07b4cdf