### PR TITLE
Update cashlogy loading dialog

### DIFF
--- a/comerzzia-pampling-pos-gui/src/main/java/com/comerzzia/pampling/pos/core/gui/componentes/CashlogyVentanaCargando.java
+++ b/comerzzia-pampling-pos-gui/src/main/java/com/comerzzia/pampling/pos/core/gui/componentes/CashlogyVentanaCargando.java
@@ -62,27 +62,31 @@ public class CashlogyVentanaCargando extends Stage {
 
         // Panel principal con estilo popup
         ventana.panelInterno = new BorderPane();
+        ventana.panelInterno.getStyleClass().add("mainFxmlClass");
 
         // Mensaje superior
-        Label lbMensaje = new Label(I18N.getTexto("Inserte el dinero por favor"));
+        Label lbMensaje = new Label(I18N.getTexto("Introduzca dinero"));
         VBox vBoxTop = new VBox();
         vBoxTop.setStyle("-fx-alignment: center; -fx-background-radius: 5 5 0 0; -fx-border-width:5;");
         lbMensaje.setStyle("-fx-font-size: 20px;");
         vBoxTop.getChildren().add(lbMensaje);
         vBoxTop.setPadding(new Insets(10));
+        ventana.panelInterno.setTop(vBoxTop);
 
         // Rueda de carga
         ventana.cargando = new ProgressIndicator();
         ventana.cargando.setPrefSize(70, 70);
 
-        VBox vBoxCentro = new VBox(ventana.cargando);
+        Label lbCargando = new Label(I18N.getTexto("Cargando..."));
+        VBox vBoxCentro = new VBox(ventana.cargando, lbCargando);
         vBoxCentro.setAlignment(Pos.CENTER);
+        vBoxCentro.setSpacing(10);
         vBoxCentro.setPadding(new Insets(10, 10, 10, 10));
         ventana.panelInterno.setCenter(vBoxCentro);
 
         // Botón Cancelar
-        Button btnCancelar = new Button("Cancelar");
-        btnCancelar.setStyle("-fx-font-size: 14px; -fx-padding: 6 20;");
+        Button btnCancelar = new Button(I18N.getTexto("Cancelar"));
+        btnCancelar.getStyleClass().add("btCancelar");
         btnCancelar.setOnAction(event -> {
             log.info("Botón Cancelar pulsado");
             if (onCancel != null) {

--- a/comerzzia-pampling-pos-gui/src/main/java/com/comerzzia/pampling/pos/gui/ventas/tickets/pagos/PamplingPagosController.java
+++ b/comerzzia-pampling-pos-gui/src/main/java/com/comerzzia/pampling/pos/gui/ventas/tickets/pagos/PamplingPagosController.java
@@ -235,7 +235,7 @@ public class PamplingPagosController extends PagosController {
 		final String codMedioPagoFinal = codMedioPago;
 		if (((PamplingPaymentsManagerImpl) paymentsManager).isCashlogyEnable() && medioPagoSeleccionado.equals(MediosPagosService.medioPagoDefecto)) {
 
-			new CashlogyTask<Void>(){
+                    CashlogyTask<Void> task = new CashlogyTask<Void>(){
 
 				@Override
 				protected Void call() throws Exception {
@@ -271,11 +271,13 @@ public class PamplingPagosController extends PagosController {
 					btAnotarPago.setDisable(false);
 
 				}
-                        }.start(getStage(), () -> {
+                    }; // end of anonymous CashlogyTask
+                    task.setCancelAction(() -> {
                                 if (paymentMethodManager instanceof CashlogyManager) {
                                         ((CashlogyManager) paymentMethodManager).requestCancelSale();
                                 }
                         });
+                        task.start(getStage());
 
 		}
 		else {

--- a/comerzzia-pampling-pos-gui/src/main/java/com/comerzzia/pampling/pos/services/payments/methods/types/CashlogyTask.java
+++ b/comerzzia-pampling-pos-gui/src/main/java/com/comerzzia/pampling/pos/services/payments/methods/types/CashlogyTask.java
@@ -10,12 +10,16 @@ import javafx.stage.Stage;
 public abstract class CashlogyTask<V> extends BackgroundTask<V> {
 
         protected Stage stage;
-        protected Runnable cancelAction;
+    protected Runnable cancelAction;
 	
 	private static Logger log = Logger.getLogger(CashlogyTask.class);
 	
-        public void start(Stage stageR) {
-                start(stageR, null);
+    public void start(Stage stageR) {
+        start(stageR, null);
+    }
+
+    public void setCancelAction(Runnable cancelAction) {
+        this.cancelAction = cancelAction;
     }
 
         public void start(Stage stageR, Runnable cancelAction) {


### PR DESCRIPTION
## Summary
- update the cashlogy loading dialog text and layout
- use base styling for panel and buttons
- expose cancel action setter and adjust payment controller

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685147d49224832bb332df1bc6b59fc0