### PR TITLE
Add styled loading window for Cashlogy

### DIFF
--- a/comerzzia-pampling-pos-gui/src/main/java/com/comerzzia/pampling/pos/core/gui/componentes/CashlogyVentanaCargando.java
+++ b/comerzzia-pampling-pos-gui/src/main/java/com/comerzzia/pampling/pos/core/gui/componentes/CashlogyVentanaCargando.java
@@ -62,27 +62,30 @@ public class CashlogyVentanaCargando extends Stage {
 
         // Panel principal con estilo popup
         ventana.panelInterno = new BorderPane();
+        ventana.panelInterno.setId("ventana-cargando");
 
-        // Mensaje superior
-        Label lbMensaje = new Label(I18N.getTexto("Inserte el dinero por favor"));
-        VBox vBoxTop = new VBox();
-        vBoxTop.setStyle("-fx-alignment: center; -fx-background-radius: 5 5 0 0; -fx-border-width:5;");
-        lbMensaje.setStyle("-fx-font-size: 20px;");
-        vBoxTop.getChildren().add(lbMensaje);
-        vBoxTop.setPadding(new Insets(10));
+        // Cabecera
+        Label lbHeader = new Label("Introduzca dinero");
+        lbHeader.setId("header-text");
+        VBox vBoxTop = new VBox(lbHeader);
+        vBoxTop.setId("header-box");
+        vBoxTop.setAlignment(Pos.CENTER);
+        vBoxTop.setPadding(new Insets(12));
+        ventana.panelInterno.setTop(vBoxTop);
 
         // Rueda de carga
         ventana.cargando = new ProgressIndicator();
         ventana.cargando.setPrefSize(70, 70);
+        ventana.cargando.getStyleClass().add("progress-cargando");
 
         VBox vBoxCentro = new VBox(ventana.cargando);
         vBoxCentro.setAlignment(Pos.CENTER);
-        vBoxCentro.setPadding(new Insets(10, 10, 10, 10));
+        vBoxCentro.setPadding(new Insets(10));
         ventana.panelInterno.setCenter(vBoxCentro);
 
         // Botón Cancelar
         Button btnCancelar = new Button("Cancelar");
-        btnCancelar.setStyle("-fx-font-size: 14px; -fx-padding: 6 20;");
+        btnCancelar.setId("btn-cancelar");
         btnCancelar.setOnAction(event -> {
             log.info("Botón Cancelar pulsado");
             if (onCancel != null) {
@@ -105,6 +108,7 @@ public class CashlogyVentanaCargando extends Stage {
         ventana.scene.setFill(Color.TRANSPARENT);
 
         POSApplication.getInstance().addBaseCSS(ventana.scene); // Tu CSS base, si aplica
+        ventana.scene.getStylesheets().add("/styles/dialog.css");
         ventana.setScene(ventana.scene);
 
         ventana.initOwner(stageOwner);

--- a/comerzzia-pampling-pos-gui/src/main/resources/styles/dialog.css
+++ b/comerzzia-pampling-pos-gui/src/main/resources/styles/dialog.css
@@ -1,0 +1,37 @@
+/* panel principal */
+#ventana-cargando {
+  -fx-background-color: white;
+  -fx-border-color: #CCC;
+  -fx-border-radius: 8;
+  -fx-background-radius: 8;
+  -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.2), 8,0,0,2);
+}
+
+/* cabecera */
+#header-box {
+  -fx-background-color: linear-gradient(to bottom, #F5F5F5, #E0E0E0);
+  -fx-background-radius: 8 8 0 0;
+}
+#header-text {
+  -fx-font-size: 18px;
+  -fx-text-fill: #333;
+  -fx-font-weight: bold;
+}
+
+/* progress indicator (opcional) */
+.progress-cargando {
+  -fx-progress-color: #2196F3;
+}
+
+/* botón cancelar */
+#btn-cancelar {
+  -fx-font-size: 14px;
+  -fx-padding: 6 20;
+  -fx-background-radius: 4;
+  -fx-background-color: #E53935;
+  -fx-text-fill: white;
+}
+#btn-cancelar:hover {
+  -fx-background-color: #D32F2F;
+}
+


### PR DESCRIPTION
## Summary
- style the Cashlogy loading dialog with IDs and external CSS
- add new dialog.css stylesheet

## Testing
- `mvn -q package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68515050aa78832b8b849435b8ca9d01