### PR TITLE
Fix gift card check on payments

### DIFF
--- a/comerzzia-bimbaylola-pos-gui/src/main/java/com/comerzzia/bimbaylola/pos/gui/pagos/ByLPagosController.java
+++ b/comerzzia-bimbaylola-pos-gui/src/main/java/com/comerzzia/bimbaylola/pos/gui/pagos/ByLPagosController.java
@@ -788,13 +788,9 @@ public class ByLPagosController extends PagosController {
 	}
 
 	@Override
-	public void initializeFocus() {
-		restaurarFocoTFImporte();
-		/* Añadimos la condición de que debe tener permisos para poder pagar con tarjeta regalo. */
-		if (pedirTarjetaRegalo && comprobarPermisosPagos()) {
-			procesarPagoTarjetaRegalo(mediosPagosService.getMedioPago(COD_MP_ABONO));
-		}
-	}
+       public void initializeFocus() {
+               restaurarFocoTFImporte();
+       }
 	
 	@Override
 	public void initializeComponents() {
@@ -1096,9 +1092,12 @@ public class ByLPagosController extends PagosController {
 		return limitePagoEfectivo;
 	}
 
-	protected void procesarPagoTarjetaRegalo(final MedioPagoBean medioPagoBean) {
-		log.info("procesarPagoTarjetaRegalo() - Iniciamos el procesamiento del Pago con Tarjeta Regalo...");
-		try {
+       protected void procesarPagoTarjetaRegalo(final MedioPagoBean medioPagoBean) {
+               log.info("procesarPagoTarjetaRegalo() - Iniciamos el procesamiento del Pago con Tarjeta Regalo...");
+               if (!Dispositivos.getInstance().getGiftCard().isMedioPagoGiftCard(medioPagoBean.getCodMedioPago())) {
+                       return;
+               }
+               try {
 			if (ticketManager.getTicket().getCabecera().getTarjetaRegalo() == null) {
 				Stage stage = null;
 				


### PR DESCRIPTION
## Summary
- avoid auto gift card flow on screen load
- only trigger gift card workflow when gift card payment is chosen

## Testing
- `mvn -q -DskipTests install` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d2c3d6500832bb765cbed2bd09521