### PR TITLE
Fix gift card balance after failed payment

### DIFF
--- a/comerzzia-bimbaylola-pos-gui/src/main/java/com/comerzzia/bimbaylola/pos/gui/ventas/tickets/ByLTicketManager.java
+++ b/comerzzia-bimbaylola-pos-gui/src/main/java/com/comerzzia/bimbaylola/pos/gui/ventas/tickets/ByLTicketManager.java
@@ -1279,11 +1279,18 @@ public class ByLTicketManager extends TicketManager implements ByLTicketRegalo{
 			callback.onFailure(ex);
 		}
 
-		@Override
-		protected void succeeded() {
-			super.succeeded();
-			callback.onSucceeded();
-		}
+                @Override
+                protected void succeeded() {
+                        super.succeeded();
+                        /*
+                         * Clear the list of gift cards with provisional
+                         * movements to avoid applying compensations on
+                         * subsequent transactions when the current ticket has
+                         * been successfully completed.
+                         */
+                        SpringContext.getBean(ByLGiftCard.class).limpiarListaTarjetasRegaloAnulables();
+                        callback.onSucceeded();
+                }
 
 	}
 


### PR DESCRIPTION
## Summary
- clear pending gift card movements once a ticket finishes successfully

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e48edbbb4832b96c5f98124fb1693