### PR TITLE
Fix closing caja log null uid

### DIFF
--- a/pos-gui/src/main/java/com/comerzzia/bricodepot/pos/gui/ventas/cajas/cierre/BricodepotCierreCajaController.java
+++ b/pos-gui/src/main/java/com/comerzzia/bricodepot/pos/gui/ventas/cajas/cierre/BricodepotCierreCajaController.java
@@ -137,8 +137,9 @@ public class BricodepotCierreCajaController extends CierreCajaController {
 				sesion.getSesionCaja().actualizarDatosCaja();
 				transferirCajaAMaster(formularioCierreCaja.getDateCierre());
 			}
-			cajaSesion.cerrarCaja();
-			log.debug("accionCierreCaja() - Caja " + cajaSesion.getUidDiarioCaja() + " cerrada exitosamente.");
+                        String uidDiarioCaja = cajaSesion.getUidDiarioCaja();
+                        cajaSesion.cerrarCaja();
+                        log.debug("accionCierreCaja() - Caja " + uidDiarioCaja + " cerrada exitosamente.");
 			
 			
 			


### PR DESCRIPTION
## Summary
- avoid null UID in caja closing log by capturing uidDiarioCaja before closing

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864f377fa58832b8ed884c2053f03f5