### PR TITLE
feat: add 25% discount toggle button

### DIFF
--- a/comerzzia-ametller-pos-application/src/main/java/com/comerzzia/ametller/pos/gui/ventas/tickets/AmetllerTicketManager.java
+++ b/comerzzia-ametller-pos-application/src/main/java/com/comerzzia/ametller/pos/gui/ventas/tickets/AmetllerTicketManager.java
@@ -1,0 +1,58 @@
+package com.comerzzia.ametller.pos.gui.ventas.tickets;
+
+import java.math.BigDecimal;
+
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import com.comerzzia.pos.gui.ventas.tickets.TicketManager;
+import com.comerzzia.pos.services.ticket.lineas.LineaTicket;
+import com.comerzzia.pos.services.ticket.lineas.LineaTicketException;
+
+import javafx.stage.Stage;
+
+/**
+ * Especialización del {@link TicketManager} estándar que permite activar un
+ * descuento manual del 25% para las líneas que se añadan al ticket mientras la
+ * opción esté habilitada.
+ */
+@Component
+@Scope("prototype")
+@Primary
+public class AmetllerTicketManager extends TicketManager {
+
+    private static final BigDecimal DESCUENTO = new BigDecimal("25.00");
+
+    /** Indica si el descuento automático está activo. */
+    private boolean descuento25Activo = false;
+
+    /**
+     * Alterna el estado del descuento automático del 25%.
+     *
+     * @return {@code true} si tras la llamada el descuento queda activado.
+     */
+    public boolean toggleDescuento25() {
+        descuento25Activo = !descuento25Activo;
+        return descuento25Activo;
+    }
+
+    /**
+     * @return {@code true} si el descuento automático está actualmente activo.
+     */
+    public boolean isDescuento25Activo() {
+        return descuento25Activo;
+    }
+
+    @Override
+    public synchronized LineaTicket nuevaLineaArticulo(String codArticulo, String desglose1,
+            String desglose2, BigDecimal cantidad, Stage stage, Integer idLineaDocOrigen,
+            boolean esLineaDevolucionPositiva, boolean applyDUN14Factor) throws LineaTicketException {
+        LineaTicket linea = super.nuevaLineaArticulo(codArticulo, desglose1, desglose2, cantidad,
+                stage, idLineaDocOrigen, esLineaDevolucionPositiva, applyDUN14Factor);
+        if (descuento25Activo && linea != null) {
+            linea.setDescuentoManual(DESCUENTO);
+        }
+        return linea;
+    }
+}

--- a/comerzzia-ametller-pos-application/src/main/java/com/comerzzia/ametller/pos/gui/ventas/tickets/articulos/AmetllerFacturacionArticulosController.java
+++ b/comerzzia-ametller-pos-application/src/main/java/com/comerzzia/ametller/pos/gui/ventas/tickets/articulos/AmetllerFacturacionArticulosController.java
@@ -1,0 +1,43 @@
+package com.comerzzia.ametller.pos.gui.ventas.tickets.articulos;
+
+import com.comerzzia.pos.core.gui.InitializeGuiException;
+import com.comerzzia.pos.gui.ventas.tickets.articulos.FacturacionArticulosController;
+import com.comerzzia.ametller.pos.gui.ventas.tickets.AmetllerTicketManager;
+
+import javafx.scene.control.Button;
+import javafx.scene.layout.AnchorPane;
+import org.springframework.stereotype.Component;
+
+/**
+ * Controlador personalizado que extiende del controlador estándar de
+ * facturación para añadir un botón que permite activar/desactivar un
+ * descuento automático del 25 % para las líneas que se creen a partir de
+ * su pulsación.
+ */
+@Component
+public class AmetllerFacturacionArticulosController extends FacturacionArticulosController {
+
+    /** Botón para activar/desactivar el descuento del 25 %. */
+    private Button btnDescuento25;
+
+    @Override
+    public void initializeComponents() throws InitializeGuiException {
+        super.initializeComponents();
+
+        btnDescuento25 = new Button("25% DESCUENTO");
+        AnchorPane.setTopAnchor(btnDescuento25, 5.0);
+        AnchorPane.setRightAnchor(btnDescuento25, 5.0);
+        btnDescuento25.setOnAction(e -> {
+            if (ticketManager instanceof AmetllerTicketManager) {
+                AmetllerTicketManager manager = (AmetllerTicketManager) ticketManager;
+                boolean activo = manager.toggleDescuento25();
+                if (activo) {
+                    btnDescuento25.getStyleClass().add("active-discount");
+                } else {
+                    btnDescuento25.getStyleClass().remove("active-discount");
+                }
+            }
+        });
+        panelBotonera.getChildren().add(btnDescuento25);
+    }
+}


### PR DESCRIPTION
## Summary
- add AmetllerTicketManager that can toggle a 25% manual discount on new lines
- introduce AmetllerFacturacionArticulosController with a "25% DESCUENTO" button to toggle the discount while keeping the standard controller untouched

## Testing
- `mvn -q -e test` *(fails: Non-resolvable import POM: com.comerzzia.pos:comerzzia-pos-dependencies:pom:4.8.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68bad8c30380832b92c67c801437518b