### PR TITLE
feat: add discount toggle button to sales screen

### DIFF
--- a/comerzzia-ametller-pos-gui/src/main/java/com/comerzzia/ametller/pos/gui/ventas/tickets/articulos/AmetllerFacturacionArticulosController.java
+++ b/comerzzia-ametller-pos-gui/src/main/java/com/comerzzia/ametller/pos/gui/ventas/tickets/articulos/AmetllerFacturacionArticulosController.java
@@ -4,6 +4,7 @@ import com.comerzzia.pos.core.gui.InitializeGuiException;
 import com.comerzzia.pos.gui.ventas.tickets.articulos.FacturacionArticulosController;
 import com.comerzzia.ametller.pos.gui.ventas.tickets.AmetllerTicketManager;
 
+import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.layout.AnchorPane;
 import org.springframework.stereotype.Component;
@@ -11,16 +12,19 @@ import org.springframework.stereotype.Component;
 @Component
 public class AmetllerFacturacionArticulosController extends FacturacionArticulosController {
 
-	private Button btnDescuento25;
+        @FXML
+        private AnchorPane panelDescuento25;
+
+        private Button btnDescuento25;
 
 	@Override
 	public void initializeComponents() throws InitializeGuiException {
 		super.initializeComponents();
 
-		btnDescuento25 = new Button("25% DESCUENTO");
-		AnchorPane.setTopAnchor(btnDescuento25, 5.0);
-		AnchorPane.setRightAnchor(btnDescuento25, 5.0);
-		btnDescuento25.setOnAction(e -> {
+                btnDescuento25 = new Button("25% DESCUENTO");
+                AnchorPane.setTopAnchor(btnDescuento25, 5.0);
+                AnchorPane.setRightAnchor(btnDescuento25, 5.0);
+                btnDescuento25.setOnAction(e -> {
 			if (ticketManager instanceof AmetllerTicketManager) {
 				AmetllerTicketManager manager = (AmetllerTicketManager) ticketManager;
 				boolean activo = manager.toggleDescuento25();
@@ -32,6 +36,6 @@ public class AmetllerFacturacionArticulosController extends FacturacionArticulos
 				}
 			}
 		});
-		panelBotonera.getChildren().add(btnDescuento25);
-	}
+                panelDescuento25.getChildren().add(btnDescuento25);
+        }
 }

--- a/comerzzia-ametller-pos-gui/src/resources/skins/ametller/com/comerzzia/pos/gui/ventas/tickets/articulos/facturacionarticulos.fxml
+++ b/comerzzia-ametller-pos-gui/src/resources/skins/ametller/com/comerzzia/pos/gui/ventas/tickets/articulos/facturacionarticulos.fxml
@@ -14,7 +14,7 @@
 <?import javafx.scene.text.*?>
 <?scenebuilder-preview-i18n-resource ../../../i18n/Bundle.properties?>
 
-<AnchorPane id="AnchorPane" prefHeight="700.0" prefWidth="1024.0" style="&#10;" styleClass="mainFxmlClass" xmlns:fx="http://javafx.com/fxml/1" xmlns="http://javafx.com/javafx/2.2" fx:controller="com.comerzzia.pos.gui.ventas.tickets.articulos.FacturacionArticulosController">
+<AnchorPane id="AnchorPane" prefHeight="700.0" prefWidth="1024.0" style="&#10;" styleClass="mainFxmlClass" xmlns:fx="http://javafx.com/fxml/1" xmlns="http://javafx.com/javafx/2.2" fx:controller="com.comerzzia.ametller.pos.gui.ventas.tickets.articulos.AmetllerFacturacionArticulosController">
   <children>
     <HBox prefHeight="600.0" prefWidth="800.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
       <children>
@@ -147,6 +147,7 @@
                         <Insets />
                       </HBox.margin>
                     </AnchorPane>
+                    <AnchorPane fx:id="panelDescuento25" prefHeight="189.0" prefWidth="150.0" />
                     <AnchorPane minWidth="0.0" prefHeight="193.0" prefWidth="0.0" />
                     <AnchorPane id="AnchorPane" minWidth="246.0" prefHeight="185.0" prefWidth="246.0" HBox.hgrow="NEVER">
                       <children>


### PR DESCRIPTION
## Summary
- Link Facturación Artículos view to custom controller and reserve panel for 25% discount button
- Add discount toggle button to dedicated panel to apply 25% manual discount on scanned items

## Testing
- `mvn -q -e -pl comerzzia-ametller-pos-gui -am test` *(fails: 'dependencies.dependency.version' for org.slf4j:log4j-over-slf4j is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68be7c4a1650832b84dfaf0c8c1c8749