### PR TITLE
fix: configure maven repo and artifact path

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,6 @@ build:maven:
   script:
     - mvn $MAVEN_CLI_OPTS -U package -DskipTests -Dgenerate-pos-lib
   artifacts:
-    paths:
-      - pos-gui/target/lib
-    expire_in: 1 hour
+      paths:
+        - comerzzia-ametller-pos-gui/target/lib
+      expire_in: 1 hour

--- a/.m2/settings.xml
+++ b/.m2/settings.xml
@@ -30,17 +30,17 @@
 	</activeProfiles>
 
 	<servers>
-		<!-- artifactory credentials -->
-		<server>
-			<id>artifactory</id>
-			<username>${env.MAVEN_REPO_USER}</username>
-			<password>${env.MAVEN_REPO_PASS}</password>		   
-		</server>
-		<server>
-			<id>clientes</id>
-			<username>${env.MAVEN_REPO_USER}</username>
-			<password>${env.MAVEN_REPO_PASS}</password>		   
-		</server>		
-	</servers>
+               <!-- Artifactory credentials -->
+               <server>
+                       <id>comerzzia</id>
+                       <username>${env.MAVEN_REPO_USER}</username>
+                       <password>${env.MAVEN_REPO_PASS}</password>
+               </server>
+               <server>
+                       <id>clientes</id>
+                       <username>${env.MAVEN_REPO_USER}</username>
+                       <password>${env.MAVEN_REPO_PASS}</password>
+               </server>
+       </servers>
 </settings>
 


### PR DESCRIPTION
## Summary
- configure artifactory server id to match repo
- correct artifacts path for GUI module

## Testing
- `mvn -q -s .m2/settings.xml package -DskipTests -Dgenerate-pos-lib` *(fails: Non-resolvable import POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c042f507e8832bb70f47c84701290d