### PR TITLE
Avoid saving tickets after payment registration errors

### DIFF
--- a/comerzzia-iskaypet-pos-gui/src/main/java/com/comerzzia/iskaypet/pos/gui/ventas/tickets/IskaypetTicketManager.java
+++ b/comerzzia-iskaypet-pos-gui/src/main/java/com/comerzzia/iskaypet/pos/gui/ventas/tickets/IskaypetTicketManager.java
@@ -199,6 +199,12 @@ public class IskaypetTicketManager extends TicketManager {
     @Autowired
     protected SesionImpuestos sesionImpuestos;
 
+    /**
+     * Indica si se ha producido algún error durante el proceso de pagos.
+     * Si es <code>true</code> no se permitirá registrar el ticket.
+     */
+    private boolean paymentError;
+
     @Autowired
     protected ServicioConfigContadores servicioConfigContadores;
 
@@ -804,6 +810,14 @@ public class IskaypetTicketManager extends TicketManager {
         return ticketConsultaPromociones;
     }
 
+    public boolean isPaymentError() {
+        return paymentError;
+    }
+
+    public void setPaymentError(boolean paymentError) {
+        this.paymentError = paymentError;
+    }
+
     @Override
     public void salvarTicketSeguridad(Stage stage, SalvarTicketCallback callback) {
         new SalvarTicketSeguridadIskaypetTask(stage, callback).start();
@@ -909,13 +923,25 @@ public class IskaypetTicketManager extends TicketManager {
 
             redondearImportesTicket();
 
+            if (isPaymentError()) {
+                throw new TicketsServiceException("Error al registrar los pagos del ticket.");
+            }
+
+            if (CollectionUtils.isEmpty(ticketPrincipal.getLineas())) {
+                throw new TicketsServiceException("El ticket no contiene líneas de artículos.");
+            }
+
+            if (CollectionUtils.isEmpty(ticketPrincipal.getPagos())) {
+                throw new TicketsServiceException("El ticket no contiene medios de pago.");
+            }
+
+            confirmarPagosTarjeta(pagosAutorizados, stage);
+
             // boolean processTicket = esDevolucion || esFacturacionVentaCredito ||
             // !ticketPrincipal.getCuponesAplicados().isEmpty();
             boolean processTicket = false;
 
             ticketsService.registrarTicket((Ticket) ticketPrincipal, documentoActivo, processTicket);
-
-            confirmarPagosTarjeta(pagosAutorizados, stage);
 
             return null;
         }
@@ -2894,8 +2920,9 @@ public class IskaypetTicketManager extends TicketManager {
 
     @Override
     public void inicializarTicket() throws DocumentoException, PromocionesServiceException {
-    	mostrarTrazaReducida();
+        mostrarTrazaReducida();
         super.inicializarTicket();
+        paymentError = false;
     }
 
     public void mostrarTrazaReducida() {

--- a/comerzzia-iskaypet-pos-gui/src/main/java/com/comerzzia/iskaypet/pos/gui/ventas/tickets/pagos/IskaypetPagosController.java
+++ b/comerzzia-iskaypet-pos-gui/src/main/java/com/comerzzia/iskaypet/pos/gui/ventas/tickets/pagos/IskaypetPagosController.java
@@ -88,6 +88,7 @@ import com.comerzzia.pos.services.payments.configuration.PaymentsMethodsConfigur
 import com.comerzzia.pos.services.payments.events.PaymentOkEvent;
 import com.comerzzia.pos.services.payments.events.PaymentsOkEvent;
 import com.comerzzia.pos.services.payments.events.PaymentsSelectEvent;
+import com.comerzzia.pos.services.payments.events.PaymentsErrorEvent;
 import com.comerzzia.pos.services.payments.methods.PaymentMethodManager;
 import com.comerzzia.pos.services.payments.methods.types.BasicPaymentMethodManager;
 import com.comerzzia.pos.services.payments.methods.types.GiftCardManager;
@@ -1552,23 +1553,28 @@ public class IskaypetPagosController extends PagosController {
 		}
 	}
 
-	private void gestionarPagoSipay() {
-		try {
-			if (StringUtils.isNotBlank(medioPagoSeleccionado.getCodMedioPago()) &&
-					SipayConstants.MANAGER_CONTROL_CLASS.equals(medioPagoSeleccionado.getClaseControl()) &&
-					BigDecimalUtil.isIgualACero(ticketManager.getTicket().getTotales().getPendiente())) {
-				aceptar();
-			}
-		}
-		catch (Exception e) {
-			log.error("gestionarPagoSipay() - " + e.getMessage());
-			VentanaDialogoComponent.crearVentanaError(e.getMessage(), getStage());
-		}
-	}
+        private void gestionarPagoSipay() {
+                try {
+                        if (StringUtils.isNotBlank(medioPagoSeleccionado.getCodMedioPago()) &&
+                                        SipayConstants.MANAGER_CONTROL_CLASS.equals(medioPagoSeleccionado.getClaseControl()) &&
+                                        BigDecimalUtil.isIgualACero(ticketManager.getTicket().getTotales().getPendiente()) &&
+                                        !ticketManager.getTicket().getPagos().isEmpty()) {
+                                if (ticketManager instanceof IskaypetTicketManager &&
+                                                ((IskaypetTicketManager) ticketManager).isPaymentError()) {
+                                        return;
+                                }
+                                aceptar();
+                        }
+                }
+                catch (Exception e) {
+                        log.error("gestionarPagoSipay() - " + e.getMessage());
+                        VentanaDialogoComponent.crearVentanaError(e.getMessage(), getStage());
+                }
+        }
 
 	@Override
-	protected void processPaymentOk(PaymentsOkEvent event) {
-		PaymentOkEvent eventOk = event.getOkEvent();
+        protected void processPaymentOk(PaymentsOkEvent event) {
+                PaymentOkEvent eventOk = event.getOkEvent();
 
 		if (!eventOk.isCanceled()) {
 			addPayment(eventOk);
@@ -1577,15 +1583,26 @@ public class IskaypetPagosController extends PagosController {
 			deletePayment(eventOk);
 		}
 
-		Platform.runLater(() -> {
-			refrescarDatosPantalla();
-			// Si se ha pagado a través de Sipay y el importe restante a pagar es 0, se acepta automáticamente
-			gestionarPagoSipay();
-			if (!isDevolucion()) {
-				selectDefaultPaymentMethod();
-			}
-		});
-	}
+                Platform.runLater(() -> {
+                        refrescarDatosPantalla();
+                        // Si se ha pagado a través de Sipay y el importe restante a pagar es 0, se acepta automáticamente
+                        gestionarPagoSipay();
+                        if (!isDevolucion()) {
+                                selectDefaultPaymentMethod();
+                        }
+                });
+        }
+
+        @Override
+        protected void processPaymentError(PaymentsErrorEvent event) {
+                super.processPaymentError(event);
+
+                if (ticketManager instanceof IskaypetTicketManager) {
+                        ((IskaypetTicketManager) ticketManager).setPaymentError(true);
+                }
+
+                enProceso = false;
+        }
 
 	/*
 	 * ##############################################################################################################
@@ -1646,18 +1663,21 @@ public class IskaypetPagosController extends PagosController {
 			addCustomPaymentData(eventOk, payment);
 		}
 
-		if (paymentMethod.getTarjetaCredito() != null && paymentMethod.getTarjetaCredito()) {
-			if (eventOk.getExtendedData().containsKey(BasicPaymentMethodManager.PARAM_RESPONSE_TEF)) {
-				log.debug("addPayment() - Adding extended data.");
-				DatosRespuestaPagoTarjeta datosRespuestaPagoTarjeta = (DatosRespuestaPagoTarjeta) eventOk.getExtendedData().get(BasicPaymentMethodManager.PARAM_RESPONSE_TEF);
-				payment.setDatosRespuestaPagoTarjeta(datosRespuestaPagoTarjeta);
-				for (String key : eventOk.getExtendedData().keySet()) {
-					payment.addExtendedData(key, eventOk.getExtendedData().get(key));
-				}
-			}
-		}
-		ticketManager.guardarCopiaSeguridadTicket();
-	}
+                if (paymentMethod.getTarjetaCredito() != null && paymentMethod.getTarjetaCredito()) {
+                        if (eventOk.getExtendedData().containsKey(BasicPaymentMethodManager.PARAM_RESPONSE_TEF)) {
+                                log.debug("addPayment() - Adding extended data.");
+                                DatosRespuestaPagoTarjeta datosRespuestaPagoTarjeta = (DatosRespuestaPagoTarjeta) eventOk.getExtendedData().get(BasicPaymentMethodManager.PARAM_RESPONSE_TEF);
+                                payment.setDatosRespuestaPagoTarjeta(datosRespuestaPagoTarjeta);
+                                for (String key : eventOk.getExtendedData().keySet()) {
+                                        payment.addExtendedData(key, eventOk.getExtendedData().get(key));
+                                }
+                        }
+                }
+                if (ticketManager instanceof IskaypetTicketManager) {
+                        ((IskaypetTicketManager) ticketManager).setPaymentError(false);
+                }
+                ticketManager.guardarCopiaSeguridadTicket();
+        }
 
 	@Override
 	public void asociarPagoTarjetaRegalo(Boolean venta, GiftCardBean giftCard) {


### PR DESCRIPTION
## Summary
- Reset payment error state on each new ticket
- Stop Sipay auto-finalization when payments fail or are missing
- Refuse ticket registration if a payment error occurred or there are no lines/pagos

## Testing
- `mvn -q -pl comerzzia-iskaypet-pos-gui -am -Dmaven.test.skip=false test` *(fails: Non-resolvable import POM: Could not transfer artifact com.comerzzia.pos:comerzzia-pos-dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b348c934832bbbbea4f6c275f009