### PR TITLE
Prevent incomplete tickets on payment errors

### DIFF
--- a/comerzzia-iskaypet-pos-gui/src/main/java/com/comerzzia/iskaypet/pos/gui/ventas/tickets/articulos/IskaypetFacturacionArticulosController.java
+++ b/comerzzia-iskaypet-pos-gui/src/main/java/com/comerzzia/iskaypet/pos/gui/ventas/tickets/articulos/IskaypetFacturacionArticulosController.java
@@ -1069,15 +1069,24 @@ public class IskaypetFacturacionArticulosController extends FacturacionArticulos
 				}
 			}
 		}
-		else {
-			log.warn("abrirPagosSinCupones() - Ticket vacio");
-			VentanaDialogoComponent.crearVentanaAviso(I18N.getTexto("El ticket no contiene lineas de articulo."), this.getStage());
-		}
-	}
+                else {
+                        log.warn("abrirPagosSinCupones() - Ticket vacio");
+                        VentanaDialogoComponent.crearVentanaAviso(I18N.getTexto("El ticket no contiene lineas de articulo."), this.getStage());
+                }
+        }
+
+       @Override
+       protected void crearNuevoTicket() throws PromocionesServiceException, DocumentoException {
+               if (ticketManager.isTicketAbierto()) {
+                       log.debug("crearNuevoTicket() - Ticket en curso, no se crea uno nuevo");
+                       return;
+               }
+               super.crearNuevoTicket();
+       }
 
 
-	@Override
-	public void cancelarVenta() {
+       @Override
+       public void cancelarVenta() {
 		log.debug("cancelarVenta()");
 		try {
 			boolean confirmacion = VentanaDialogoComponent.crearVentanaConfirmacion(I18N.getTexto("¿Está seguro de querer eliminar todas las líneas del ticket?"), getStage());

--- a/comerzzia-iskaypet-pos-gui/src/main/java/com/comerzzia/iskaypet/pos/gui/ventas/tickets/pagos/IskaypetPagosController.java
+++ b/comerzzia-iskaypet-pos-gui/src/main/java/com/comerzzia/iskaypet/pos/gui/ventas/tickets/pagos/IskaypetPagosController.java
@@ -78,6 +78,7 @@ import com.comerzzia.pos.persistence.tickets.datosfactura.DatosFactura;
 import com.comerzzia.pos.persistence.tiposIdent.TiposIdentBean;
 import com.comerzzia.pos.services.core.documentos.DocumentoException;
 import com.comerzzia.pos.services.core.documentos.Documentos;
+import com.comerzzia.pos.services.payments.events.PaymentErrorEvent;
 import com.comerzzia.pos.services.core.tiposIdent.TiposIdentNotFoundException;
 import com.comerzzia.pos.services.core.tiposIdent.TiposIdentService;
 import com.comerzzia.pos.services.core.tiposIdent.TiposIdentServiceException;
@@ -87,6 +88,8 @@ import com.comerzzia.pos.services.payments.configuration.PaymentMethodConfigurat
 import com.comerzzia.pos.services.payments.configuration.PaymentsMethodsConfiguration;
 import com.comerzzia.pos.services.payments.events.PaymentOkEvent;
 import com.comerzzia.pos.services.payments.events.PaymentsOkEvent;
+import com.comerzzia.pos.services.payments.events.PaymentsErrorEvent;
+import com.comerzzia.pos.services.payments.events.PaymentsCompletedEvent;
 import com.comerzzia.pos.services.payments.events.PaymentsSelectEvent;
 import com.comerzzia.pos.services.payments.methods.PaymentMethodManager;
 import com.comerzzia.pos.services.payments.methods.types.BasicPaymentMethodManager;
@@ -157,7 +160,9 @@ import static com.comerzzia.pos.gui.ventas.tickets.pagos.cambioPagos.VentanaCamb
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public class IskaypetPagosController extends PagosController {
 
-	protected Logger log = Logger.getLogger(getClass());
+        protected Logger log = Logger.getLogger(getClass());
+
+       private PaymentErrorEvent ultimoErrorPago;
 
 	public static final String MEDIOS_PAGOS_SIN_AUTORIZACION = "X_POS.MEDIOS_PAGOS_SIN_AUTORIZACION";
 	public static final String MEDIOS_PAGOS_MOSTRAR_CAMBIO = "X_POS.MEDIOS_PAGOS_MOSTRAR_CAMBIO";
@@ -1566,26 +1571,49 @@ public class IskaypetPagosController extends PagosController {
 		}
 	}
 
-	@Override
-	protected void processPaymentOk(PaymentsOkEvent event) {
-		PaymentOkEvent eventOk = event.getOkEvent();
+        @Override
+        protected void processPaymentOk(PaymentsOkEvent event) {
+                PaymentOkEvent eventOk = event.getOkEvent();
+               if (!eventOk.isCanceled()) {
+                       addPayment(eventOk);
+               } else {
+                       deletePayment(eventOk);
+               }
 
-		if (!eventOk.isCanceled()) {
-			addPayment(eventOk);
-		}
-		else {
-			deletePayment(eventOk);
-		}
+               if (BigDecimalUtil.isIgualACero(ticketManager.getTicket().getTotales().getPendiente())) {
+                       ultimoErrorPago = null;
+               }
 
-		Platform.runLater(() -> {
-			refrescarDatosPantalla();
-			// Si se ha pagado a través de Sipay y el importe restante a pagar es 0, se acepta automáticamente
-			gestionarPagoSipay();
-			if (!isDevolucion()) {
-				selectDefaultPaymentMethod();
-			}
-		});
-	}
+               Platform.runLater(() -> {
+                       refrescarDatosPantalla();
+                       // Si se ha pagado a través de Sipay y el importe restante a pagar es 0, se acepta automáticamente
+                       gestionarPagoSipay();
+                       if (!isDevolucion()) {
+                               selectDefaultPaymentMethod();
+                       }
+                       boolean pendiente = !BigDecimalUtil.isIgualACero(ticketManager.getTicket().getTotales().getPendiente());
+                       btAceptar.setDisable(ultimoErrorPago != null || pendiente);
+               });
+       }
+
+       @Override
+       protected void processPaymentError(PaymentsErrorEvent event) {
+               super.processPaymentError(event);
+               ultimoErrorPago = event.getErrorEvent();
+               btAceptar.setDisable(true);
+       }
+
+       @Override
+       protected void finishSale(final PaymentsCompletedEvent event) {
+               super.finishSale(event);
+               boolean pendiente = !BigDecimalUtil.isIgualACero(ticketManager.getTicket().getTotales().getPendiente());
+               if (ultimoErrorPago != null || pendiente) {
+                       btAceptar.setDisable(true);
+                       btCancelar.setDisable(false);
+               } else {
+                       btAceptar.setDisable(false);
+               }
+       }
 
 	/*
 	 * ##############################################################################################################

--- a/comerzzia-iskaypet-pos-gui/src/main/java/com/comerzzia/iskaypet/pos/services/ticket/IskaypetTicketService.java
+++ b/comerzzia-iskaypet-pos-gui/src/main/java/com/comerzzia/iskaypet/pos/services/ticket/IskaypetTicketService.java
@@ -44,6 +44,8 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
@@ -403,20 +405,33 @@ public class IskaypetTicketService extends TicketsService {
 
 
 
-	@Override
-	public synchronized void registrarTicket(Ticket ticket, TipoDocumentoBean tipoDocumento, boolean procesarTicket) throws TicketsServiceException {
-		log.debug("registrarTicket() - Registrando ticket con id: " + ticket.getIdTicket() + ", total entregado de: " + ticket.getCabecera().getTotales().getEntregadoAsString() + " y un total a pagar de: " + ticket.getCabecera().getTotales().getTotalAPagar());
-		log.debug("registrarTicket() - Cantidad total de líneas: " + ticket.getLineas().size());
-		try {
-			for (Object obj : ticket.getPagos()) {
-				IPagoTicket pago = (IPagoTicket) obj;
-				log.debug("registrarTicket() - Pago del ticket con medio de pago: " + pago.getDesMedioPago() + " y un importe de: " + pago.getImporte());
-			}
-		}
-		catch (Exception e) {
-			log.error("registrarTicket() - Error al recorrer los pagos del ticket" + e.getMessage(), e);
-		}
-		super.registrarTicket(ticket, tipoDocumento, procesarTicket);
-	}
+        @Override
+        @Transactional(propagation = Propagation.REQUIRED, rollbackFor = Exception.class)
+        public synchronized void registrarTicket(Ticket ticket, TipoDocumentoBean tipoDocumento, boolean procesarTicket) throws TicketsServiceException {
+                log.debug("registrarTicket() - Registrando ticket con id: " + ticket.getIdTicket() + ", total entregado de: " + ticket.getCabecera().getTotales().getEntregadoAsString() + " y un total a pagar de: " + ticket.getCabecera().getTotales().getTotalAPagar());
+                log.debug("registrarTicket() - Cantidad total de líneas: " + ticket.getLineas().size());
+
+                if (ticket.getLineas().isEmpty() || ticket.getPagos().isEmpty()) {
+                        throw new IllegalStateException("El ticket debe contener líneas y pagos");
+                }
+
+                BigDecimal totalAPagar = ticket.getCabecera().getTotales().getTotalAPagar();
+                BigDecimal totalEntregado = ticket.getCabecera().getTotales().getEntregado();
+                if (totalEntregado.compareTo(totalAPagar) < 0) {
+                        throw new IllegalStateException("El total entregado es inferior al total a pagar");
+                }
+
+                try {
+                        for (Object obj : ticket.getPagos()) {
+                                IPagoTicket pago = (IPagoTicket) obj;
+                                log.debug("registrarTicket() - Pago del ticket con medio de pago: " + pago.getDesMedioPago() + " y un importe de: " + pago.getImporte());
+                        }
+                        super.registrarTicket(ticket, tipoDocumento, procesarTicket);
+                }
+                catch (Exception e) {
+                        log.error("registrarTicket() - Error al registrar el ticket", e);
+                        throw e;
+                }
+        }
 
 }


### PR DESCRIPTION
## Summary
- drop ticket state machine and restore standard initialization
- block checkout when a payment error occurs and re-enable only after resolving the pending amount
- skip creating a new ticket when one is already open
- track the last payment error using PaymentErrorEvent to mirror standard variable naming

## Testing
- `mvn -q -e -pl comerzzia-iskaypet-pos-gui -am test` *(fails: dependencies.dependency.version for org.slf4j:log4j-over-slf4j is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c7df5da0cc832b90214a50c3fd6b8a