### PR TITLE
Prevent incomplete tickets on payment errors

### DIFF
--- a/comerzzia-iskaypet-pos-gui/src/main/java/com/comerzzia/iskaypet/pos/gui/ventas/tickets/articulos/IskaypetFacturacionArticulosController.java
+++ b/comerzzia-iskaypet-pos-gui/src/main/java/com/comerzzia/iskaypet/pos/gui/ventas/tickets/articulos/IskaypetFacturacionArticulosController.java
@@ -1069,15 +1069,24 @@ public class IskaypetFacturacionArticulosController extends FacturacionArticulos
 				}
 			}
 		}
-		else {
-			log.warn("abrirPagosSinCupones() - Ticket vacio");
-			VentanaDialogoComponent.crearVentanaAviso(I18N.getTexto("El ticket no contiene lineas de articulo."), this.getStage());
-		}
-	}
+                else {
+                        log.warn("abrirPagosSinCupones() - Ticket vacio");
+                        VentanaDialogoComponent.crearVentanaAviso(I18N.getTexto("El ticket no contiene lineas de articulo."), this.getStage());
+                }
+        }
+
+       @Override
+       protected void crearNuevoTicket() throws PromocionesServiceException, DocumentoException {
+               if (ticketManager.isTicketAbierto()) {
+                       log.debug("crearNuevoTicket() - Ticket en curso, no se crea uno nuevo");
+                       return;
+               }
+               super.crearNuevoTicket();
+       }
 
 
-	@Override
-	public void cancelarVenta() {
+       @Override
+       public void cancelarVenta() {
 		log.debug("cancelarVenta()");
 		try {
 			boolean confirmacion = VentanaDialogoComponent.crearVentanaConfirmacion(I18N.getTexto("¿Está seguro de querer eliminar todas las líneas del ticket?"), getStage());

--- a/comerzzia-iskaypet-pos-gui/src/main/java/com/comerzzia/iskaypet/pos/gui/ventas/tickets/pagos/IskaypetPagosController.java
+++ b/comerzzia-iskaypet-pos-gui/src/main/java/com/comerzzia/iskaypet/pos/gui/ventas/tickets/pagos/IskaypetPagosController.java
@@ -78,6 +78,7 @@ import com.comerzzia.pos.persistence.tickets.datosfactura.DatosFactura;
 import com.comerzzia.pos.persistence.tiposIdent.TiposIdentBean;
 import com.comerzzia.pos.services.core.documentos.DocumentoException;
 import com.comerzzia.pos.services.core.documentos.Documentos;
+import com.comerzzia.pos.services.payments.events.PaymentErrorEvent;
 import com.comerzzia.pos.services.core.tiposIdent.TiposIdentNotFoundException;
 import com.comerzzia.pos.services.core.tiposIdent.TiposIdentService;
 import com.comerzzia.pos.services.core.tiposIdent.TiposIdentServiceException;
@@ -87,6 +88,8 @@ import com.comerzzia.pos.services.payments.configuration.PaymentMethodConfigurat
 import com.comerzzia.pos.services.payments.configuration.PaymentsMethodsConfiguration;
 import com.comerzzia.pos.services.payments.events.PaymentOkEvent;
 import com.comerzzia.pos.services.payments.events.PaymentsOkEvent;
+import com.comerzzia.pos.services.payments.events.PaymentsErrorEvent;
+import com.comerzzia.pos.services.payments.events.PaymentsCompletedEvent;
 import com.comerzzia.pos.services.payments.events.PaymentsSelectEvent;
 import com.comerzzia.pos.services.payments.methods.PaymentMethodManager;
 import com.comerzzia.pos.services.payments.methods.types.BasicPaymentMethodManager;
@@ -157,7 +160,9 @@ import static com.comerzzia.pos.gui.ventas.tickets.pagos.cambioPagos.VentanaCamb
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public class IskaypetPagosController extends PagosController {
 
-	protected Logger log = Logger.getLogger(getClass());
+        protected Logger log = Logger.getLogger(getClass());
+
+       private PaymentErrorEvent ultimoErrorPago;
 
 	public static final String MEDIOS_PAGOS_SIN_AUTORIZACION = "X_POS.MEDIOS_PAGOS_SIN_AUTORIZACION";
 	public static final String MEDIOS_PAGOS_MOSTRAR_CAMBIO = "X_POS.MEDIOS_PAGOS_MOSTRAR_CAMBIO";
@@ -1566,26 +1571,48 @@ public class IskaypetPagosController extends PagosController {
 		}
 	}
 
-	@Override
-	protected void processPaymentOk(PaymentsOkEvent event) {
-		PaymentOkEvent eventOk = event.getOkEvent();
+        @Override
+        protected void processPaymentOk(PaymentsOkEvent event) {
+                PaymentOkEvent eventOk = event.getOkEvent();
+               if (!eventOk.isCanceled()) {
+                       addPayment(eventOk);
+               } else {
+                       deletePayment(eventOk);
+               }
 
-		if (!eventOk.isCanceled()) {
-			addPayment(eventOk);
-		}
-		else {
-			deletePayment(eventOk);
-		}
+               if (BigDecimalUtil.isIgualACero(ticketManager.getTicket().getTotales().getPendiente())) {
+                       ultimoErrorPago = null;
+               }
 
-		Platform.runLater(() -> {
-			refrescarDatosPantalla();
-			// Si se ha pagado a través de Sipay y el importe restante a pagar es 0, se acepta automáticamente
-			gestionarPagoSipay();
-			if (!isDevolucion()) {
-				selectDefaultPaymentMethod();
-			}
-		});
-	}
+               Platform.runLater(() -> {
+                       refrescarDatosPantalla();
+                       // Si se ha pagado a través de Sipay y el importe restante a pagar es 0, se acepta automáticamente
+                       gestionarPagoSipay();
+                       if (!isDevolucion()) {
+                               selectDefaultPaymentMethod();
+                       }
+                       boolean pendiente = !BigDecimalUtil.isIgualACero(ticketManager.getTicket().getTotales().getPendiente());
+                       btAceptar.setDisable(ultimoErrorPago != null || pendiente);
+               });
+       }
+
+       @Override
+       protected void processPaymentError(PaymentsErrorEvent event) {
+               super.processPaymentError(event);
+               ultimoErrorPago = event.getErrorEvent();
+               btAceptar.setDisable(true);
+       }
+
+       @Override
+       protected void finishSale(final PaymentsCompletedEvent event) {
+               boolean pendiente = !BigDecimalUtil.isIgualACero(ticketManager.getTicket().getTotales().getPendiente());
+               if (ultimoErrorPago != null || pendiente) {
+                       btAceptar.setDisable(true);
+                       btCancelar.setDisable(false);
+               } else {
+                       super.finishSale(event);
+               }
+       }
 
 	/*
 	 * ##############################################################################################################


### PR DESCRIPTION
## Summary
- require payments before ticket registration unless total to pay is zero
- keep checkout disabled when a payment error occurs or a balance remains

## Testing
- `mvn -q -e -pl comerzzia-iskaypet-pos-gui -am test` *(fails: Non-resolvable import POM; dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c7df5da0cc832b90214a50c3fd6b8a