### PR TITLE
Consolidate cash recount export

### DIFF
--- a/comerzzia-bimbaylola-pos-services/src/main/java/com/comerzzia/bimbaylola/pos/services/cajas/ByLCajasService.java
+++ b/comerzzia-bimbaylola-pos-services/src/main/java/com/comerzzia/bimbaylola/pos/services/cajas/ByLCajasService.java
@@ -677,26 +677,25 @@ public class ByLCajasService extends CajasService {
 	        catch (PaisNotFoundException | PaisServiceException e) {
 	            log.error("procesarMensajeRecuentosCaja() - No se ha podido consultar la moneda del país durante la creación del documento de recuento cierre de caja : " + e.getMessage(), e);
 	        }
-	        recuentoCajaBean.setMoneda(moneda);
-	        List<RecuentoBean> recuentosBean = new ArrayList<>();
-	        recuentoCajaBean.setRecuentos(recuentosBean);
+                recuentoCajaBean.setMoneda(moneda);
+                List<RecuentoBean> recuentosBean = new ArrayList<>();
 
-	        Integer linea = 0;
-	        for (CajaLineaRecuentoBean lineaRecuento : caja.getLineasRecuento()) {
-	            MedioPagoBean medioPago = mediosPagosService.getMedioPago(lineaRecuento.getCodMedioPago());
-	            if (!medioPago.getRecuentoAutomaticoCaja()) {
-	                RecuentoBean recuentoBean = new RecuentoBean();
-	                recuentoBean.setLinea(linea.toString());
-	                recuentoBean.setUidActividad(sesion.getAplicacion().getUidActividad());
-	                recuentoBean.setCodMedioPago(lineaRecuento.getCodMedioPago());
-	                recuentoBean.setCantidad(lineaRecuento.getCantidad());
-	                recuentoBean.setValor(lineaRecuento.getValor().setScale(2));
-	                recuentosBean.add(recuentoBean);
-	                linea++;
-	            }
-	        }
+                for (CajaLineaRecuentoBean lineaRecuento : caja.getLineasRecuento()) {
+                    MedioPagoBean medioPago = mediosPagosService.getMedioPago(lineaRecuento.getCodMedioPago());
+                    if (!medioPago.getRecuentoAutomaticoCaja()) {
+                        RecuentoBean recuentoBean = new RecuentoBean();
+                        recuentoBean.setUidActividad(sesion.getAplicacion().getUidActividad());
+                        recuentoBean.setCodMedioPago(lineaRecuento.getCodMedioPago());
+                        recuentoBean.setCantidad(lineaRecuento.getCantidad());
+                        recuentoBean.setValor(lineaRecuento.getValor().setScale(2));
+                        recuentosBean.add(recuentoBean);
+                    }
+                }
 
-	        ticket.setTicket(MarshallUtil.crearXML(recuentoCajaBean));
+                List<RecuentoBean> recuentosConsolidados = RecuentoExportConsolidator.consolidate(recuentosBean);
+                recuentoCajaBean.setRecuentos(recuentosConsolidados);
+
+                ticket.setTicket(MarshallUtil.crearXML(recuentoCajaBean));
 	        log.debug("TICKET: " + ticket.getUidTicket() + "\n" + new String(ticket.getTicket(), "UTF-8") + "\n");
 
 	        ticketsService.insertarTicket(sqlSession, ticket, false);

--- a/comerzzia-bimbaylola-pos-services/src/main/java/com/comerzzia/bimbaylola/pos/services/cajas/RecuentoExportConsolidator.java
+++ b/comerzzia-bimbaylola-pos-services/src/main/java/com/comerzzia/bimbaylola/pos/services/cajas/RecuentoExportConsolidator.java
@@ -1,0 +1,82 @@
+package com.comerzzia.bimbaylola.pos.services.cajas;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.comerzzia.bimbaylola.pos.persistence.cajas.recuentos.RecuentoBean;
+
+/**
+ * Utility class that consolidates the cash lines (codMedioPago "0000") of a
+ * recount before exporting it.
+ */
+public final class RecuentoExportConsolidator {
+
+    private static final String COD_MEDIO_PAGO_EFECTIVO = "0000";
+
+    private RecuentoExportConsolidator() {
+        // Utility class
+    }
+
+    public static List<RecuentoBean> consolidate(List<RecuentoBean> recuentos) {
+        if (recuentos == null || recuentos.isEmpty()) {
+            return recuentos == null ? Collections.emptyList() : recuentos;
+        }
+
+        List<RecuentoBean> resultado = new ArrayList<>();
+
+        BigDecimal totalEfectivo = BigDecimal.ZERO;
+        BigDecimal totalEfectivoAbono = BigDecimal.ZERO;
+        boolean totalEfectivoAbonoInicializado = false;
+        RecuentoBean plantillaEfectivo = null;
+        int indiceInsercionEfectivo = -1;
+
+        for (RecuentoBean recuento : recuentos) {
+            if (COD_MEDIO_PAGO_EFECTIVO.equals(recuento.getCodMedioPago())) {
+                if (plantillaEfectivo == null) {
+                    plantillaEfectivo = recuento;
+                    indiceInsercionEfectivo = resultado.size();
+                }
+
+                BigDecimal cantidad = recuento.getCantidad() != null
+                        ? BigDecimal.valueOf(recuento.getCantidad().longValue())
+                        : BigDecimal.ZERO;
+                BigDecimal valor = recuento.getValor() != null ? recuento.getValor() : BigDecimal.ZERO;
+                totalEfectivo = totalEfectivo.add(valor.multiply(cantidad));
+
+                BigDecimal valorAbono = recuento.getValorAbono();
+                if (valorAbono != null) {
+                    totalEfectivoAbono = totalEfectivoAbono.add(valorAbono.multiply(cantidad));
+                    totalEfectivoAbonoInicializado = true;
+                }
+            } else {
+                resultado.add(recuento);
+            }
+        }
+
+        if (plantillaEfectivo != null) {
+            RecuentoBean efectivoConsolidado = new RecuentoBean();
+            // We reuse the uidActividad from the first cash line to keep the same
+            // activity identifier expected by the downstream contracts.
+            efectivoConsolidado.setUidActividad(plantillaEfectivo.getUidActividad());
+            efectivoConsolidado.setCodMedioPago(COD_MEDIO_PAGO_EFECTIVO);
+            efectivoConsolidado.setCantidad(Integer.valueOf(1));
+            efectivoConsolidado.setValor(totalEfectivo.setScale(2, RoundingMode.HALF_UP));
+            if (totalEfectivoAbonoInicializado) {
+                efectivoConsolidado.setValorAbono(totalEfectivoAbono.setScale(2, RoundingMode.HALF_UP));
+            }
+            efectivoConsolidado.setIdD365(plantillaEfectivo.getIdD365());
+            efectivoConsolidado.setIdD365Abono(plantillaEfectivo.getIdD365Abono());
+
+            resultado.add(indiceInsercionEfectivo, efectivoConsolidado);
+        }
+
+        for (int i = 0; i < resultado.size(); i++) {
+            resultado.get(i).setLinea(String.valueOf(i));
+        }
+
+        return resultado;
+    }
+}


### PR DESCRIPTION
## Summary
- add a helper that consolidates cash recount lines into a single aggregated movement before exporting
- apply the consolidation when building the recount payload so only one cash entry is serialized

## Testing
- `mvn -pl comerzzia-bimbaylola-pos-services -am -DskipTests package` *(fails: blocked mirror for Maven plugin repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cd34b7a93c832bb480e037aa45edae