### PR TITLE
Rename cash recount helper with Spanish naming

### DIFF
--- a/comerzzia-bimbaylola-pos-services/src/main/java/com/comerzzia/bimbaylola/pos/services/cajas/ByLCajasService.java
+++ b/comerzzia-bimbaylola-pos-services/src/main/java/com/comerzzia/bimbaylola/pos/services/cajas/ByLCajasService.java
@@ -677,26 +677,25 @@ public class ByLCajasService extends CajasService {
 	        catch (PaisNotFoundException | PaisServiceException e) {
 	            log.error("procesarMensajeRecuentosCaja() - No se ha podido consultar la moneda del país durante la creación del documento de recuento cierre de caja : " + e.getMessage(), e);
 	        }
-	        recuentoCajaBean.setMoneda(moneda);
-	        List<RecuentoBean> recuentosBean = new ArrayList<>();
-	        recuentoCajaBean.setRecuentos(recuentosBean);
+                recuentoCajaBean.setMoneda(moneda);
+                List<RecuentoBean> recuentosBean = new ArrayList<>();
 
-	        Integer linea = 0;
-	        for (CajaLineaRecuentoBean lineaRecuento : caja.getLineasRecuento()) {
-	            MedioPagoBean medioPago = mediosPagosService.getMedioPago(lineaRecuento.getCodMedioPago());
-	            if (!medioPago.getRecuentoAutomaticoCaja()) {
-	                RecuentoBean recuentoBean = new RecuentoBean();
-	                recuentoBean.setLinea(linea.toString());
-	                recuentoBean.setUidActividad(sesion.getAplicacion().getUidActividad());
-	                recuentoBean.setCodMedioPago(lineaRecuento.getCodMedioPago());
-	                recuentoBean.setCantidad(lineaRecuento.getCantidad());
-	                recuentoBean.setValor(lineaRecuento.getValor().setScale(2));
-	                recuentosBean.add(recuentoBean);
-	                linea++;
-	            }
-	        }
+                for (CajaLineaRecuentoBean lineaRecuento : caja.getLineasRecuento()) {
+                    MedioPagoBean medioPago = mediosPagosService.getMedioPago(lineaRecuento.getCodMedioPago());
+                    if (!medioPago.getRecuentoAutomaticoCaja()) {
+                        RecuentoBean recuentoBean = new RecuentoBean();
+                        recuentoBean.setUidActividad(sesion.getAplicacion().getUidActividad());
+                        recuentoBean.setCodMedioPago(lineaRecuento.getCodMedioPago());
+                        recuentoBean.setCantidad(lineaRecuento.getCantidad());
+                        recuentoBean.setValor(lineaRecuento.getValor().setScale(2));
+                        recuentosBean.add(recuentoBean);
+                    }
+                }
 
-	        ticket.setTicket(MarshallUtil.crearXML(recuentoCajaBean));
+                List<RecuentoBean> recuentosAgrupados = ByLRecuentoEfectivoAgrupador.agruparLineas(recuentosBean);
+                recuentoCajaBean.setRecuentos(recuentosAgrupados);
+
+                ticket.setTicket(MarshallUtil.crearXML(recuentoCajaBean));
 	        log.debug("TICKET: " + ticket.getUidTicket() + "\n" + new String(ticket.getTicket(), "UTF-8") + "\n");
 
 	        ticketsService.insertarTicket(sqlSession, ticket, false);

--- a/comerzzia-bimbaylola-pos-services/src/main/java/com/comerzzia/bimbaylola/pos/services/cajas/ByLRecuentoEfectivoAgrupador.java
+++ b/comerzzia-bimbaylola-pos-services/src/main/java/com/comerzzia/bimbaylola/pos/services/cajas/ByLRecuentoEfectivoAgrupador.java
@@ -1,0 +1,82 @@
+package com.comerzzia.bimbaylola.pos.services.cajas;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.comerzzia.bimbaylola.pos.persistence.cajas.recuentos.RecuentoBean;
+
+/**
+ * Agrupa las líneas de efectivo (codMedioPago "0000") de un recuento antes de
+ * exportarlo.
+ */
+public final class ByLRecuentoEfectivoAgrupador {
+
+    private static final String COD_MEDIO_PAGO_EFECTIVO = "0000";
+
+    private ByLRecuentoEfectivoAgrupador() {
+        // Clase de utilidades
+    }
+
+    public static List<RecuentoBean> agruparLineas(List<RecuentoBean> recuentos) {
+        if (recuentos == null || recuentos.isEmpty()) {
+            return recuentos == null ? Collections.emptyList() : recuentos;
+        }
+
+        List<RecuentoBean> resultado = new ArrayList<>();
+
+        BigDecimal totalEfectivo = BigDecimal.ZERO;
+        BigDecimal totalEfectivoAbono = BigDecimal.ZERO;
+        boolean tieneImporteAbono = false;
+        RecuentoBean primeraLineaEfectivo = null;
+        int posicionLineaEfectivo = -1;
+
+        for (RecuentoBean recuento : recuentos) {
+            if (COD_MEDIO_PAGO_EFECTIVO.equals(recuento.getCodMedioPago())) {
+                if (primeraLineaEfectivo == null) {
+                    primeraLineaEfectivo = recuento;
+                    posicionLineaEfectivo = resultado.size();
+                }
+
+                BigDecimal cantidad = recuento.getCantidad() != null
+                        ? BigDecimal.valueOf(recuento.getCantidad().longValue())
+                        : BigDecimal.ZERO;
+                BigDecimal valor = recuento.getValor() != null ? recuento.getValor() : BigDecimal.ZERO;
+                totalEfectivo = totalEfectivo.add(valor.multiply(cantidad));
+
+                BigDecimal valorAbono = recuento.getValorAbono();
+                if (valorAbono != null) {
+                    totalEfectivoAbono = totalEfectivoAbono.add(valorAbono.multiply(cantidad));
+                    tieneImporteAbono = true;
+                }
+            } else {
+                resultado.add(recuento);
+            }
+        }
+
+        if (primeraLineaEfectivo != null) {
+            RecuentoBean lineaEfectivoAgrupada = new RecuentoBean();
+            // Reutilizamos el uidActividad de la primera línea de efectivo para mantener
+            // el identificador de actividad esperado por los contratos posteriores.
+            lineaEfectivoAgrupada.setUidActividad(primeraLineaEfectivo.getUidActividad());
+            lineaEfectivoAgrupada.setCodMedioPago(COD_MEDIO_PAGO_EFECTIVO);
+            lineaEfectivoAgrupada.setCantidad(Integer.valueOf(1));
+            lineaEfectivoAgrupada.setValor(totalEfectivo.setScale(2, RoundingMode.HALF_UP));
+            if (tieneImporteAbono) {
+                lineaEfectivoAgrupada.setValorAbono(totalEfectivoAbono.setScale(2, RoundingMode.HALF_UP));
+            }
+            lineaEfectivoAgrupada.setIdD365(primeraLineaEfectivo.getIdD365());
+            lineaEfectivoAgrupada.setIdD365Abono(primeraLineaEfectivo.getIdD365Abono());
+
+            resultado.add(posicionLineaEfectivo, lineaEfectivoAgrupada);
+        }
+
+        for (int i = 0; i < resultado.size(); i++) {
+            resultado.get(i).setLinea(String.valueOf(i));
+        }
+
+        return resultado;
+    }
+}


### PR DESCRIPTION
## Summary
- rename the cash recount helper to `ByLRecuentoEfectivoAgrupador` and adjust its API to Spanish terminology
- update `ByLCajasService` to call the renamed helper when grouping cash recount lines before export

## Testing
- `mvn -pl comerzzia-bimbaylola-pos-services -am -DskipTests package` *(fails: blocked mirror for Maven plugin repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cd34b7a93c832bb480e037aa45edae