### PR TITLE
Add detailed redeemed coupon messaging

### DIFF
--- a/comerzzia-dinosol-pos-gui/src/main/java/com/comerzzia/dinosol/pos/gui/ventas/tickets/DinoTicketManager.java
+++ b/comerzzia-dinosol-pos-gui/src/main/java/com/comerzzia/dinosol/pos/gui/ventas/tickets/DinoTicketManager.java
@@ -948,7 +948,7 @@ public class DinoTicketManager extends TicketManager {
                         return defaults;
                 }
                 try {
-                        JsonElement root = JsonParser.parseString(jsonPayload);
+                        JsonElement root = new JsonParser().parse(jsonPayload);
                         String dateValue = findFirstStringValue(root, COUPON_REDEEM_DATE_KEYS);
                         String centerValue = findFirstStringValue(root, COUPON_REDEEM_CENTER_KEYS);
                         String ticketValue = findFirstStringValue(root, COUPON_REDEEM_TICKET_KEYS);

--- a/comerzzia-dinosol-pos-gui/src/main/java/com/comerzzia/dinosol/pos/gui/ventas/tickets/DinoTicketManager.java
+++ b/comerzzia-dinosol-pos-gui/src/main/java/com/comerzzia/dinosol/pos/gui/ventas/tickets/DinoTicketManager.java
@@ -2,6 +2,14 @@ package com.comerzzia.dinosol.pos.gui.ventas.tickets;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -115,6 +123,10 @@ import com.comerzzia.pos.util.i18n.I18N;
 import com.comerzzia.pos.util.xml.MarshallUtil;
 import com.comerzzia.rest.client.tickets.ResponseGetTicketDev;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 import javafx.stage.Stage;
 
 @Component
@@ -122,11 +134,17 @@ import javafx.stage.Stage;
 @Scope("prototype")
 public class DinoTicketManager extends TicketManager {
 
-	private Logger log = Logger.getLogger(DinoTicketManager.class);
-	
-	public static Long ID_TIPO_PROMO_FICITIA_CUPON = -1L;
+        private Logger log = Logger.getLogger(DinoTicketManager.class);
 
-	public static final String ARTICULO_UNITARIO = "U";
+        public static Long ID_TIPO_PROMO_FICITIA_CUPON = -1L;
+
+        public static final String ARTICULO_UNITARIO = "U";
+
+        private static final String[] COUPON_REDEEM_DATE_KEYS = { "redeemDate", "redeemedDate", "redeemedOn", "redemptionDate", "fechaCanje", "fechaRedencion", "fechaRedemption" };
+        private static final String[] COUPON_REDEEM_CENTER_KEYS = { "center", "centerCode", "store", "storeCode", "storeId", "centro", "codCentro" };
+        private static final String[] COUPON_REDEEM_TICKET_KEYS = { "ticket", "ticketNumber", "numeroTicket", "numTicket", "ticketId", "ticket_code" };
+        private static final String REDEEM_UNKNOWN_VALUE = "DESCONOCIDO";
+        private static final DateTimeFormatter REDEEM_DATE_OUTPUT_FORMAT = DateTimeFormatter.ofPattern("dd/MM/yyyy");
 		
 	@Autowired 
 	private DinoCodBarrasEspecialesServices dinoCodBarrasEspecialesService;
@@ -859,12 +877,12 @@ public class DinoTicketManager extends TicketManager {
 			try {
 				CouponDTO couponDto = ((DinoSesionPromociones) sesionPromociones).validateCoupon(codArticulo);
 				
-                    if(couponDto == null) {
-                            Integer lastStatus = ((DinoSesionPromociones) sesionPromociones).getLastCouponValidationStatus();
-                            if(lastStatus != null && lastStatus == 400) {
-                                    throw new CuponAplicationException(I18N.getTexto("El cupón ya ha sido redimido."));
-                            }
-                    }
+                               if(couponDto == null) {
+                                       Integer lastStatus = ((DinoSesionPromociones) sesionPromociones).getLastCouponValidationStatus();
+                                       if(lastStatus != null && lastStatus == 400) {
+                                               throw new CuponAplicationException(buildRedeemedCouponMessage(codArticulo));
+                                       }
+                               }
 
 				for(CustomerCouponDTO cupon : getCuponesLeidos()) {
 					if(cupon.getCouponCode().equals(codArticulo)) {
@@ -910,8 +928,123 @@ public class DinoTicketManager extends TicketManager {
 			isCupon = true;
 		}
 		
-		return isCupon;
-	}
+                return isCupon;
+        }
+
+        private String buildRedeemedCouponMessage(String couponCode) {
+                String sanitizedCouponCode = defaultIfBlank(couponCode, REDEEM_UNKNOWN_VALUE);
+                String rawMessage = ((DinoSesionPromociones) sesionPromociones).getLastCouponValidationMessage();
+                String[] redemptionData = parseRedeemedCouponData(rawMessage);
+                return "CUPÓN " + sanitizedCouponCode + " CANJEADO EL DIA " + redemptionData[0] + " EN EL CENTRO " + redemptionData[1] + " EN EL NÚMERO DE TICKET " + redemptionData[2];
+        }
+
+        private String[] parseRedeemedCouponData(String rawMessage) {
+                String[] defaults = new String[] { REDEEM_UNKNOWN_VALUE, REDEEM_UNKNOWN_VALUE, REDEEM_UNKNOWN_VALUE };
+                if(StringUtils.isBlank(rawMessage)) {
+                        return defaults;
+                }
+                String jsonPayload = extractJsonPayload(rawMessage);
+                if(StringUtils.isBlank(jsonPayload)) {
+                        return defaults;
+                }
+                try {
+                        JsonElement root = JsonParser.parseString(jsonPayload);
+                        String dateValue = findFirstStringValue(root, COUPON_REDEEM_DATE_KEYS);
+                        String centerValue = findFirstStringValue(root, COUPON_REDEEM_CENTER_KEYS);
+                        String ticketValue = findFirstStringValue(root, COUPON_REDEEM_TICKET_KEYS);
+                        return new String[] {
+                                        formatRedeemedDate(dateValue),
+                                        defaultIfBlank(centerValue, REDEEM_UNKNOWN_VALUE),
+                                        defaultIfBlank(ticketValue, REDEEM_UNKNOWN_VALUE)
+                        };
+                }
+                catch (JsonSyntaxException exception) {
+                        log.warn("comprobarCupon() - No se ha podido parsear la respuesta de validación del cupón: " + jsonPayload, exception);
+                        return defaults;
+                }
+        }
+
+        private String extractJsonPayload(String rawMessage) {
+                if(StringUtils.isBlank(rawMessage)) {
+                        return null;
+                }
+                int start = rawMessage.indexOf('{');
+                int end = rawMessage.lastIndexOf('}');
+                if(start >= 0 && end >= start) {
+                        return rawMessage.substring(start, end + 1);
+                }
+                return rawMessage;
+        }
+
+        private String findFirstStringValue(JsonElement element, String[] keys) {
+                if(element == null || keys == null) {
+                        return null;
+                }
+                if(element.isJsonObject()) {
+                        JsonObject jsonObject = element.getAsJsonObject();
+                        for(String key : keys) {
+                                if(jsonObject.has(key) && jsonObject.get(key) != null && jsonObject.get(key).isJsonPrimitive()) {
+                                        return jsonObject.get(key).getAsString();
+                                }
+                        }
+                        for(java.util.Map.Entry<String, JsonElement> entry : jsonObject.entrySet()) {
+                                String nested = findFirstStringValue(entry.getValue(), keys);
+                                if(StringUtils.isNotBlank(nested)) {
+                                        return nested;
+                                }
+                        }
+                }
+                else if(element.isJsonArray()) {
+                        for(JsonElement child : element.getAsJsonArray()) {
+                                String nested = findFirstStringValue(child, keys);
+                                if(StringUtils.isNotBlank(nested)) {
+                                        return nested;
+                                }
+                        }
+                }
+                return null;
+        }
+
+        private String formatRedeemedDate(String value) {
+                if(StringUtils.isBlank(value)) {
+                        return REDEEM_UNKNOWN_VALUE;
+                }
+                try {
+                        return OffsetDateTime.parse(value).toLocalDate().format(REDEEM_DATE_OUTPUT_FORMAT);
+                }
+                catch (DateTimeParseException ignored) {
+                }
+                try {
+                        return LocalDateTime.parse(value).toLocalDate().format(REDEEM_DATE_OUTPUT_FORMAT);
+                }
+                catch (DateTimeParseException ignored) {
+                }
+                try {
+                        return LocalDate.parse(value).format(REDEEM_DATE_OUTPUT_FORMAT);
+                }
+                catch (DateTimeParseException ignored) {
+                }
+                try {
+                        return LocalDate.parse(value, DateTimeFormatter.ofPattern("dd/MM/yyyy")).format(REDEEM_DATE_OUTPUT_FORMAT);
+                }
+                catch (DateTimeParseException ignored) {
+                }
+                try {
+                        return LocalDate.parse(value, DateTimeFormatter.ofPattern("yyyy/MM/dd")).format(REDEEM_DATE_OUTPUT_FORMAT);
+                }
+                catch (DateTimeParseException ignored) {
+                }
+                try {
+                        return Instant.ofEpochMilli(Long.parseLong(value)).atZone(ZoneId.systemDefault()).toLocalDate().format(REDEEM_DATE_OUTPUT_FORMAT);
+                }
+                catch (NumberFormatException | DateTimeException ignored) {
+                }
+                return value;
+        }
+
+        private String defaultIfBlank(String value, String defaultValue) {
+                return StringUtils.isBlank(value) ? defaultValue : value;
+        }
 
     @SuppressWarnings("unchecked")
 	private void anularTarjetaRegalo(LineaTicketAbstract lineaNueva, TarjetaRegaloDto tarjetaRegalo) {

--- a/comerzzia-dinosol-pos-services/src/main/java/com/comerzzia/dinosol/pos/services/core/sesion/DinoSesionPromociones.java
+++ b/comerzzia-dinosol-pos-services/src/main/java/com/comerzzia/dinosol/pos/services/core/sesion/DinoSesionPromociones.java
@@ -5,6 +5,7 @@ import java.io.InputStreamReader;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -347,7 +348,10 @@ public class DinoSesionPromociones extends SesionPromociones {
                                 lastCouponValidationStatus = feignException.status();
                                 String content = null;
                                 try {
-                                        content = feignException.contentUTF8();
+                                        byte[] contentBytes = feignException.content();
+                                        if (contentBytes != null) {
+                                                content = new String(contentBytes, StandardCharsets.UTF_8);
+                                        }
                                 }
                                 catch (Exception contentException) {
                                         log.debug("validateCoupon() - Unable to extract coupon validation content: " + contentException.getMessage());

--- a/comerzzia-dinosol-pos-services/src/main/java/com/comerzzia/dinosol/pos/services/core/sesion/DinoSesionPromociones.java
+++ b/comerzzia-dinosol-pos-services/src/main/java/com/comerzzia/dinosol/pos/services/core/sesion/DinoSesionPromociones.java
@@ -342,11 +342,23 @@ public class DinoSesionPromociones extends SesionPromociones {
 			throw e;
 		}
 		catch (Exception e) {
-			if (e instanceof FeignException) {
-				FeignException feignException = (FeignException) e;
-				lastCouponValidationStatus = feignException.status();
-				lastCouponValidationMessage = feignException.getMessage();
-			}
+                        if (e instanceof FeignException) {
+                                FeignException feignException = (FeignException) e;
+                                lastCouponValidationStatus = feignException.status();
+                                String content = null;
+                                try {
+                                        content = feignException.contentUTF8();
+                                }
+                                catch (Exception contentException) {
+                                        log.debug("validateCoupon() - Unable to extract coupon validation content: " + contentException.getMessage());
+                                }
+                                if (StringUtils.isNotBlank(content)) {
+                                        lastCouponValidationMessage = content;
+                                }
+                                else {
+                                        lastCouponValidationMessage = feignException.getMessage();
+                                }
+                        }
 
 			log.error("validateCoupon() - Error while validating coupon: " + e.getMessage(), e);
 


### PR DESCRIPTION
## Summary
- capture the coupon validation response body when the API reports a redeemed coupon
- surface a formatted message with coupon, redemption date, center and ticket using parsed API data or safe fallbacks

## Testing
- mvn -pl comerzzia-dinosol-pos-gui -am -DskipTests compile *(fails: Blocked mirror for required Comerzzia dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dc7c40d24832ba704290f92c21c65)