### PR TITLE
Handle redeemed coupon validation by querying coupon details

### DIFF
--- a/comerzzia-dinosol-pos-gui/src/main/java/com/comerzzia/dinosol/pos/gui/ventas/tickets/DinoTicketManager.java
+++ b/comerzzia-dinosol-pos-gui/src/main/java/com/comerzzia/dinosol/pos/gui/ventas/tickets/DinoTicketManager.java
@@ -958,12 +958,20 @@ public class DinoTicketManager extends TicketManager {
                 String codigoCupon = (coupon != null && StringUtils.isNotBlank(coupon.getCouponCode())) ? coupon.getCouponCode()
                                 : "-";
 
-                String centroClassValue = obtenerValorPorClassId(uses, CLASS_ID_STORE);
+                Object storeIdValue = invokeGetter(coupon, "getStoreId");
+                String centroClassValue = storeIdValue != null ? StringUtils.trimToNull(storeIdValue.toString()) : null;
+                if (StringUtils.isBlank(centroClassValue)) {
+                        centroClassValue = obtenerValorPorClassId(uses, CLASS_ID_STORE);
+                }
                 if (StringUtils.isBlank(centroClassValue)) {
                         centroClassValue = obtenerValorPorClassId(coupon, CLASS_ID_STORE);
                 }
 
-                String ticketClassValue = obtenerValorPorClassId(uses, CLASS_ID_TICKET);
+                Object ticketUidValue = invokeGetter(coupon, "getTicketUid");
+                String ticketClassValue = ticketUidValue != null ? StringUtils.trimToNull(ticketUidValue.toString()) : null;
+                if (StringUtils.isBlank(ticketClassValue)) {
+                        ticketClassValue = obtenerValorPorClassId(uses, CLASS_ID_TICKET);
+                }
                 if (StringUtils.isBlank(ticketClassValue)) {
                         ticketClassValue = obtenerValorPorClassId(coupon, CLASS_ID_TICKET);
                 }

--- a/comerzzia-dinosol-pos-gui/src/main/java/com/comerzzia/dinosol/pos/gui/ventas/tickets/DinoTicketManager.java
+++ b/comerzzia-dinosol-pos-gui/src/main/java/com/comerzzia/dinosol/pos/gui/ventas/tickets/DinoTicketManager.java
@@ -973,11 +973,40 @@ public class DinoTicketManager extends TicketManager {
         }
 
         private String obtenerNumeroTicket(String ticketClassValue, String lockByTerminalId) {
-                String ticket = StringUtils.trimToNull(ticketClassValue);
+                String ticket = buscarNumeroTicketPorUid(ticketClassValue);
+                if (StringUtils.isBlank(ticket)) {
+                        ticket = StringUtils.trimToNull(ticketClassValue);
+                }
                 if (StringUtils.isBlank(ticket)) {
                         ticket = extraerParteTerminal(lockByTerminalId, false);
                 }
                 return StringUtils.isBlank(ticket) ? "-" : ticket;
+        }
+
+        private String buscarNumeroTicketPorUid(String ticketUid) {
+                String uid = StringUtils.trimToNull(ticketUid);
+                if (StringUtils.isBlank(uid)) {
+                        return null;
+                }
+
+                try {
+                        TicketBean ticketBean = ticketsService.consultarTicket(uid, sesion.getAplicacion().getUidActividad());
+                        if (ticketBean != null && ticketBean.getIdTicket() != null) {
+                                return StringUtils.trimToNull(ticketBean.getIdTicket().toString());
+                        }
+                }
+                catch (TicketsServiceException e) {
+                        if (log.isDebugEnabled()) {
+                                log.debug("buscarNumeroTicketPorUid() - No se pudo recuperar el ticket con UID " + uid, e);
+                        }
+                }
+                catch (Exception e) {
+                        if (log.isDebugEnabled()) {
+                                log.debug("buscarNumeroTicketPorUid() - Error inesperado al recuperar el ticket con UID " + uid, e);
+                        }
+                }
+
+                return null;
         }
 
         private String extraerParteTerminal(String valor, boolean primeraParte) {

--- a/comerzzia-dinosol-pos-gui/src/main/java/com/comerzzia/dinosol/pos/gui/ventas/tickets/DinoTicketManager.java
+++ b/comerzzia-dinosol-pos-gui/src/main/java/com/comerzzia/dinosol/pos/gui/ventas/tickets/DinoTicketManager.java
@@ -991,8 +991,15 @@ public class DinoTicketManager extends TicketManager {
 
                 try {
                         TicketBean ticketBean = ticketsService.consultarTicket(uid, sesion.getAplicacion().getUidActividad());
-                        if (ticketBean != null && ticketBean.getIdTicket() != null) {
-                                return StringUtils.trimToNull(ticketBean.getIdTicket().toString());
+                        if (ticketBean != null) {
+                                String codTicket = StringUtils.trimToNull(ticketBean.getCodTicket());
+                                if (StringUtils.isNotBlank(codTicket)) {
+                                        return codTicket;
+                                }
+
+                                if (ticketBean.getIdTicket() != null) {
+                                        return StringUtils.trimToNull(ticketBean.getIdTicket().toString());
+                                }
                         }
                 }
                 catch (TicketsServiceException e) {

--- a/comerzzia-dinosol-pos-services/src/main/java/com/comerzzia/dinosol/pos/services/core/sesion/DinoSesionPromociones.java
+++ b/comerzzia-dinosol-pos-services/src/main/java/com/comerzzia/dinosol/pos/services/core/sesion/DinoSesionPromociones.java
@@ -318,11 +318,11 @@ public class DinoSesionPromociones extends SesionPromociones {
 		}
 	}
 
-	public CouponDTO validateCoupon(String code) throws ApiClientException {
-		lastCouponValidationStatus = null;
-		lastCouponValidationMessage = null;
+        public CouponDTO validateCoupon(String code) throws ApiClientException {
+                lastCouponValidationStatus = null;
+                lastCouponValidationMessage = null;
 
-		try {
+                try {
 			DatosSesionBean datosSesion = new DatosSesionBean();
 			datosSesion.setUidActividad(sesion.getAplicacion().getUidActividad());
 			datosSesion.setUidInstancia(sesion.getAplicacion().getUidInstancia());
@@ -351,8 +351,35 @@ public class DinoSesionPromociones extends SesionPromociones {
 			log.error("validateCoupon() - Error while validating coupon: " + e.getMessage(), e);
 
 			return null;
-		}
-	}
+                }
+        }
+
+        public CouponDTO getCoupon(String code) throws ApiClientException {
+                try {
+                        DatosSesionBean datosSesion = new DatosSesionBean();
+                        datosSesion.setUidActividad(sesion.getAplicacion().getUidActividad());
+                        datosSesion.setUidInstancia(sesion.getAplicacion().getUidInstancia());
+                        datosSesion.setLocale(new Locale(AppConfig.idioma, AppConfig.pais));
+
+                        CouponsApi api = apiManager.getClient(datosSesion, "CouponsApi");
+
+                        log.debug("getCoupon() - Consultando en la API el cupón: " + code);
+
+                        CouponDTO coupon = api.getCoupon(code);
+
+                        log.debug("getCoupon() - Resultado de la API: " + coupon);
+
+                        return coupon;
+                }
+                catch (ApiClientException e) {
+                        log.error("getCoupon() - Error al recuperar el cupón: " + e.getMessage(), e);
+                        throw e;
+                }
+                catch (Exception e) {
+                        log.error("getCoupon() - Error al recuperar el cupón: " + e.getMessage(), e);
+                        return null;
+                }
+        }
 
 	public Integer getLastCouponValidationStatus() {
 		return lastCouponValidationStatus;


### PR DESCRIPTION
## Summary
- query the loyalty API for coupon details when validation fails with HTTP 400 to determine if the coupon is already used
- build a detailed redemption message with coupon code, redemption date, center, and ticket information for used coupons
- expose a helper in the promotions session service to retrieve coupon details from the loyalty API

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dd0b47eb8832b9c65718b5100253f)